### PR TITLE
feat(interpreter): intérprete basado en IR + visitors, OutputProvider y suite de tests (unit, integración, memoria)

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    implementation project(':parser')
 }
 
 test {

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -16,7 +16,13 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    // Limita heap para detectar leaks mas facil
+    minHeapSize = "64m"
+    maxHeapSize = "128m"
+    // Dump si hay OOM (debug)
+    jvmArgs "-XX:+HeapDumpOnOutOfMemoryError"
 }
+
 kotlin {
     jvmToolchain(21)
 }

--- a/interpreter/src/main/kotlin/Main.kt
+++ b/interpreter/src/main/kotlin/Main.kt
@@ -1,5 +1,0 @@
-package org.printscript
-
-fun main() {
-    println("Hello World!")
-}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
@@ -1,0 +1,30 @@
+package org.printscript.interpreter
+
+import node.ASTNode
+import org.printscript.interpreter.eval.Executor
+import org.printscript.interpreter.io.DefaultOutputProvider
+import org.printscript.interpreter.io.OutputProvider
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.transform.AstToIr
+
+/**
+ * - Recibe el AST del parser
+ * - Lo transforma a IR (interna del intérprete) intermediate representation
+ * - ejecuta las sentencias con visitors (Executor/Evaluator)
+ */
+class Interpreter(
+    private val output: OutputProvider = DefaultOutputProvider()
+) {
+    private val env = Environment()
+    private val exec = Executor(env, output)
+    private val adapter = AstToIr()
+
+    // Entrada publica mas tipica: AST del parser--> ejecuta
+    fun execute(ast: List<ASTNode>) {
+        val irProgram = adapter.transform(ast)    // List<StmtIR>
+        irProgram.forEach { stmt -> stmt.accept(exec) }
+    }
+
+    /** a futuro: si queremos exponer un snapshot del entorno para tests/CLI */
+    fun environmentSnapshot(): Map<String, String> = env.snapshot()
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
@@ -13,7 +13,7 @@ import org.printscript.interpreter.transform.AstToIr
  * - ejecuta las sentencias con visitors (Executor/Evaluator)
  */
 class Interpreter(
-    private val output: OutputProvider = DefaultOutputProvider()
+    output: OutputProvider = DefaultOutputProvider()
 ) {
     private val env = Environment()
     private val exec = Executor(env, output)

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
@@ -3,7 +3,6 @@ package org.printscript.interpreter.eval
 import org.printscript.interpreter.runtime.Value
 import org.printscript.interpreter.runtime.Value.Num
 import org.printscript.interpreter.runtime.Value.Str
-import org.printscript.interpreter.runtime.asString
 import org.printscript.interpreter.runtime.RuntimeError
 import org.printscript.interpreter.runtime.Environment
 import org.printscript.interpreter.ir.*
@@ -19,8 +18,13 @@ internal class Evaluator(private val env: Environment) : ExprVisitor<Value> {
         val l = b.left.accept(this)
         val r = b.right.accept(this)
         return when (b.op) {
-            Op.PLUS  -> if (l is Str || r is Str) Str(l.asString() + r.asString())
-            else Num(reqNum(l, "+") + reqNum(r, "+"))
+            Op.PLUS  -> when {
+                l is Num && r is Num -> Num(l.v + r.v)             // suma
+                l is Str && r is Str -> Str(l.v + r.v)             // concat
+                else -> throw RuntimeError(
+                    "Operador '+' no definido para ${typeName(l)} y ${typeName(r)}"
+                )
+            }
             Op.MINUS -> Num(reqNum(l, "-") - reqNum(r, "-"))
             Op.STAR  -> Num(reqNum(l, "*") * reqNum(r, "*"))
             Op.SLASH -> {
@@ -33,4 +37,9 @@ internal class Evaluator(private val env: Environment) : ExprVisitor<Value> {
 
     private fun reqNum(v: Value, ctx: String): Double =
         (v as? Num)?.v ?: throw RuntimeError("Operador '$ctx' requiere números")
+
+    private fun typeName(v: Value) = when (v) {
+        is Num -> "number"
+        is Str -> "string"
+    }
 }

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
@@ -1,0 +1,36 @@
+package org.printscript.interpreter.eval
+
+import org.printscript.interpreter.runtime.Value
+import org.printscript.interpreter.runtime.Value.Num
+import org.printscript.interpreter.runtime.Value.Str
+import org.printscript.interpreter.runtime.asString
+import org.printscript.interpreter.runtime.RuntimeError
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.ir.*
+
+// usamos visitor, evalua expresiones a valores en runtime
+internal class Evaluator(private val env: Environment) : ExprVisitor<Value> {
+
+    override fun visitNum(n: NumLit): Value = Num(n.value)
+    override fun visitStr(s: StrLit): Value = Str(s.value)
+    override fun visitId(i: IdRef): Value = env.read(i.name)
+
+    override fun visitBinary(b: Binary): Value {
+        val l = b.left.accept(this)
+        val r = b.right.accept(this)
+        return when (b.op) {
+            Op.PLUS  -> if (l is Str || r is Str) Str(l.asString() + r.asString())
+            else Num(reqNum(l, "+") + reqNum(r, "+"))
+            Op.MINUS -> Num(reqNum(l, "-") - reqNum(r, "-"))
+            Op.STAR  -> Num(reqNum(l, "*") * reqNum(r, "*"))
+            Op.SLASH -> {
+                val rv = reqNum(r, "/")
+                if (rv == 0.0) throw RuntimeError("División por cero")
+                Num(reqNum(l, "/") / rv)
+            }
+        }
+    }
+
+    private fun reqNum(v: Value, ctx: String): Double =
+        (v as? Num)?.v ?: throw RuntimeError("Operador '$ctx' requiere números")
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
@@ -1,0 +1,35 @@
+package org.printscript.interpreter.eval
+
+import org.printscript.interpreter.io.OutputProvider
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.runtimeTypeOf
+import org.printscript.interpreter.ir.*
+import org.printscript.interpreter.runtime.asString
+
+// visitor que ejecuta sentencias usando el Evaluator para expressions
+internal class Executor(
+    private val env: Environment,
+    private val output: OutputProvider
+) : StmtVisitor<Unit> {
+
+    private val eval = Evaluator(env)
+
+    override fun visitDecl(d: DeclIR) {
+        val init = d.initializer.accept(eval)
+        val actualType = runtimeTypeOf(init)
+        require(actualType == d.declaredType) {
+            "Inicialización incompatible de '${d.name}': se esperaba ${d.declaredType} y se recibió $actualType"
+        }
+        env.declare(d.name, d.declaredType, init)
+    }
+
+    override fun visitAssign(a: AssignIR) {
+        val v = a.expr.accept(eval)
+        env.assign(a.name, v)
+    }
+
+    override fun visitPrint(p: PrintIR) {
+        val v = p.expr.accept(eval)
+        output.println(v.asString())
+    }
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/io/DefaultOutputProvider.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/io/DefaultOutputProvider.kt
@@ -1,0 +1,6 @@
+package org.printscript.interpreter.io
+
+/* imprime a stdout */
+class DefaultOutputProvider : OutputProvider {
+    override fun println(text: String) = kotlin.io.println(text)
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/io/OutputProvider.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/io/OutputProvider.kt
@@ -1,0 +1,6 @@
+package org.printscript.interpreter.io
+
+/* Abstraccion de salida para testear println sin depender de System.out */
+fun interface OutputProvider {
+    fun println(text: String)
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/ir/IrNodes.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/ir/IrNodes.kt
@@ -1,0 +1,53 @@
+package org.printscript.interpreter.ir
+
+import org.printscript.interpreter.runtime.RType
+
+//sentencias
+sealed interface StmtIR { fun <R> accept(v: StmtVisitor<R>): R }
+
+data class DeclIR(val name: String, val declaredType: RType, val initializer: ExprIR) : StmtIR {
+    override fun <R> accept(v: StmtVisitor<R>): R = v.visitDecl(this)
+}
+
+data class AssignIR(val name: String, val expr: ExprIR) : StmtIR {
+    override fun <R> accept(v: StmtVisitor<R>): R = v.visitAssign(this)
+}
+
+data class PrintIR(val expr: ExprIR) : StmtIR {
+    override fun <R> accept(v: StmtVisitor<R>): R = v.visitPrint(this)
+}
+
+// expresiones
+sealed interface ExprIR { fun <R> accept(v: ExprVisitor<R>): R }
+
+data class NumLit(val value: Double) : ExprIR {
+    override fun <R> accept(v: ExprVisitor<R>): R = v.visitNum(this)
+}
+
+data class StrLit(val value: String) : ExprIR {
+    override fun <R> accept(v: ExprVisitor<R>): R = v.visitStr(this)
+}
+
+data class IdRef(val name: String) : ExprIR {
+    override fun <R> accept(v: ExprVisitor<R>): R = v.visitId(this)
+}
+
+data class Binary(val op: Op, val left: ExprIR, val right: ExprIR) : ExprIR {
+    override fun <R> accept(v: ExprVisitor<R>): R = v.visitBinary(this)
+}
+
+enum class Op { PLUS, MINUS, STAR, SLASH }
+
+// visitors
+interface ExprVisitor<R> {
+    fun visitNum(n: NumLit): R
+    fun visitStr(s: StrLit): R
+    fun visitId(i: IdRef): R
+    fun visitBinary(b: Binary): R
+}
+
+interface StmtVisitor<R> {
+    fun visitDecl(d: DeclIR): R
+    fun visitAssign(a: AssignIR): R
+    fun visitPrint(p: PrintIR): R
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/Environment.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/Environment.kt
@@ -1,0 +1,41 @@
+package org.printscript.interpreter.runtime
+
+class Environment {
+
+    private data class Var(
+        val type: RType,
+        var value: Value?,
+        var initialized: Boolean
+    )
+
+    private val vars = mutableMapOf<String, Var>()
+
+    fun declare(name: String, type: RType, init: Value?) {
+        if (name in vars) throw RuntimeError("Variable '$name' ya definida")
+        vars[name] = Var(type, init, init != null)
+    }
+
+    fun assign(name: String, value: Value) {
+        val v = vars[name] ?: throw RuntimeError("Variable '$name' no definida")
+        if (v.type != runtimeTypeOf(value)) {
+            throw RuntimeError("Asignación incompatible a '$name': se esperaba ${v.type} y se recibió ${runtimeTypeOf(value)}")
+        }
+        v.value = value
+        v.initialized = true
+    }
+
+    fun read(name: String): Value {
+        val v = vars[name] ?: throw RuntimeError("Variable '$name' no definida")
+        if (!v.initialized) throw RuntimeError("Variable '$name' usada antes de inicializar")
+        return v.value!!
+    }
+
+    // Lo usamos mas adelante. Util a futuro para tests/CLI: nos devuelve una vista stringificada del ambiente
+    fun snapshot(): Map<String, String> = vars.mapValues { (_, v) ->
+        when (val value = v.value) {
+            null -> "<uninitialized>"
+            is Value.Num -> if (value.v % 1.0 == 0.0) value.v.toLong().toString() else value.v.toString()
+            is Value.Str -> value.v
+        }
+    }
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/RuntimeError.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/RuntimeError.kt
@@ -1,0 +1,4 @@
+package org.printscript.interpreter.runtime
+
+// Errores de tiempo de ejec. del interpreter (division por 0, acceso a variable no definida, etc)
+class RuntimeError(message: String) : RuntimeException(message)

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/RuntimeValues.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/runtime/RuntimeValues.kt
@@ -1,0 +1,20 @@
+package org.printscript.interpreter.runtime
+
+/* los valores en tiempo de ejecucion d el lenguaje */
+sealed interface Value {
+    data class Num(val v: Double) : Value
+    data class Str(val v: String) : Value
+}
+
+enum class RType { NUMBER, STRING }
+
+//helpers internos
+internal fun Value.asString(): String = when (this) {
+    is Value.Num -> if (v % 1.0 == 0.0) v.toLong().toString() else v.toString()
+    is Value.Str -> v
+}
+
+internal fun runtimeTypeOf(v: Value): RType = when (v) {
+    is Value.Num -> RType.NUMBER
+    is Value.Str -> RType.STRING
+}

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/transform/AstToIr.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/transform/AstToIr.kt
@@ -1,0 +1,78 @@
+package org.printscript.interpreter.transform
+
+import node.ASTNode
+import node.AssignationNode
+import node.DeclarationNode
+import node.DoubleExpressionNode
+import node.LiteralNode
+import node.PrintNode
+import org.printscript.interpreter.ir.DeclIR
+import org.printscript.interpreter.ir.AssignIR
+import org.printscript.interpreter.ir.ExprIR
+import org.printscript.interpreter.ir.NumLit
+import org.printscript.interpreter.ir.StrLit
+import org.printscript.interpreter.ir.PrintIR
+import org.printscript.interpreter.ir.Binary
+import org.printscript.interpreter.ir.IdRef
+import org.printscript.interpreter.ir.Op
+import org.printscript.interpreter.ir.StmtIR
+import org.printscript.interpreter.runtime.RType
+
+/**
+ * usamos este adapter para transformar node.ASTNode (parser) → IR del intérprete.
+ * Es lo ÚNICO que conoce a 'node'. Si el parser cambia, tocamos SOLO esto.
+ */
+class AstToIr {
+
+    fun transform(program: List<ASTNode>): List<StmtIR> =
+        program.map { toStmt(it) }
+
+    // sentencias
+    private fun toStmt(n: ASTNode): StmtIR = when (n) {
+        is DeclarationNode -> {
+            val name = n.name
+            val declaredType = mapType(n.type)       // "number"/"string"
+            val init = toExpr(n.value)               // ASTNode --> ExprIR
+            DeclIR(name, declaredType, init)
+        }
+        is AssignationNode -> {
+            AssignIR(n.name, toExpr(n.type))
+        }
+        is PrintNode -> PrintIR(toExpr(n.expression))
+        else -> error("Nodo de sentencia no soportado: ${n::class.simpleName}")
+    }
+
+    // expressions
+    private fun toExpr(n: ASTNode): ExprIR = when (n) {
+        is LiteralNode<*> -> when (n.type.lowercase()) {
+            "number"     -> NumLit(numberFromAny(n.value))
+            "string"     -> StrLit(n.value?.toString() ?: "")
+            "identifier" -> IdRef(n.value?.toString()
+                ?: error("Identifier inválido (null)"))
+            else -> error("Tipo de literal no soportado: '${n.type}'")
+        }
+        is DoubleExpressionNode -> Binary(opFrom(n.operator), toExpr(n.left), toExpr(n.right))
+        else -> error("Nodo de expresión no soportado: ${n::class.simpleName}")
+    }
+
+    // Helpers
+    private fun mapType(s: String): RType = when (s.lowercase()) {
+        "number" -> RType.NUMBER
+        "string" -> RType.STRING
+        else -> error("Tipo de declaración desconocido '$s'")
+    }
+
+    private fun opFrom(op: String): Op = when (op) {
+        "+" -> Op.PLUS
+        "-" -> Op.MINUS
+        "*" -> Op.STAR
+        "/" -> Op.SLASH
+        else -> error("Operador desconocido '$op'")
+    }
+
+    private fun numberFromAny(v: Any?): Double = when (v) {
+        is Number -> v.toDouble()
+        is String -> v.toDoubleOrNull() ?: error("Literal number inválido: '$v'")
+        else -> error("Literal number inválido: $v")
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/BaseInterpreterIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/BaseInterpreterIT.kt
@@ -1,0 +1,23 @@
+package org.printscript.interpreter
+
+import node.*
+import org.junit.jupiter.api.Tag
+import org.printscript.interpreter.testutil.BufferOutput
+
+@Tag("integration")
+abstract class BaseInterpreterIT {
+    // Helpers AST (parser)
+    protected fun num(n: Double) = LiteralNode(n, "number")
+    protected fun str(s: String) = LiteralNode(s, "string")
+    protected fun id(name: String) = LiteralNode(name, "identifier")
+    protected fun plus(l: ASTNode, r: ASTNode)  = DoubleExpressionNode(l, "+", r)
+    protected fun minus(l: ASTNode, r: ASTNode) = DoubleExpressionNode(l, "-", r)
+    protected fun star(l: ASTNode, r: ASTNode)  = DoubleExpressionNode(l, "*", r)
+    protected fun slash(l: ASTNode, r: ASTNode) = DoubleExpressionNode(l, "/", r)
+
+    protected fun newInterpreterWithBuffer(): Pair<Interpreter, BufferOutput> {
+        val out = BufferOutput()
+        val it = Interpreter(output = out)
+        return it to out
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterEdgeCasesIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterEdgeCasesIT.kt
@@ -1,0 +1,34 @@
+package org.printscript.interpreter
+
+import node.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("integration")
+@DisplayName("Interpreter – Edge Cases")
+class InterpreterEdgeCasesIT : BaseInterpreterIT() {
+
+    @Test
+    fun `render de enteros sin ,0`() {
+        val ast = listOf(
+            PrintNode(num(2.0)),
+            PrintNode(plus(num(2.0), num(2.0)))
+        )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("2", "4"), out.lines)
+    }
+
+    @Test
+    fun `precedencia via AST anidado`() {
+        // println( (1 + 2) * 3 ) => 9  (forzamos el AST a anidar (1+2) como left)
+        val ast = listOf(
+            PrintNode(star(plus(num(1.0), num(2.0)), num(3.0)))
+        )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("9"), out.lines)
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
@@ -1,0 +1,67 @@
+package org.printscript.interpreter
+
+import node.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.runtime.RuntimeError
+
+@Tag("integration")
+@DisplayName("Interpreter – Errores")
+class InterpreterErrorsIT : BaseInterpreterIT() {
+
+    @Test
+    fun `string + number falla ( '+' estricto )`() {
+        val ast = listOf(
+            DeclarationNode("s", "string", str("hola")),
+            PrintNode(plus(id("s"), num(2025.0)))
+        )
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Operador '+' no definido"))
+    }
+
+    @Test
+    fun `division por cero`() {
+        val ast = listOf(PrintNode(slash(num(1.0), num(0.0))))
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("División por cero"))
+    }
+
+    @Test
+    fun `identificador no declarado`() {
+        val ast = listOf(PrintNode(id("x")))
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Variable 'x' no definida"))
+    }
+
+    @Test
+    fun `asignar a variable no declarada`() {
+        val ast = listOf(AssignationNode("x", num(3.0)))
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Variable 'x' no definida"))
+    }
+
+    @Test
+    fun `type mismatch en declaracion`() {
+        val ast = listOf(DeclarationNode("s", "string", num(10.0)))
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(IllegalArgumentException::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Inicialización incompatible"))
+    }
+
+    @Test
+    fun `type mismatch en asignacion`() {
+        val ast = listOf(
+            DeclarationNode("x","number", num(1.0)),
+            AssignationNode("x", str("hola"))
+        )
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Asignación incompatible"))
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -1,0 +1,52 @@
+package org.printscript.interpreter
+
+import node.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("integration")
+@DisplayName("Interpreter – Happy Path")
+class InterpreterHappyPathIT : BaseInterpreterIT() {
+
+    @Test
+    fun `declara number con precedencia, imprime, concatena string, reasigna y vuelve a imprimir`() {
+        val ast = listOf(
+            DeclarationNode("x", "number", plus(num(1.0), star(num(2.0), num(3.0)))), // 7
+            PrintNode(id("x")),
+            DeclarationNode("s", "string", str("hola")),
+            PrintNode(plus(id("s"), str("2025"))), // hola2025
+            AssignationNode("x", plus(id("x"), num(1.0))), // 8
+            PrintNode(id("x"))
+        )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("7","hola2025","8"), out.lines)
+    }
+
+    @Test
+    fun `aritmetica basica y formateo de enteros sin coma`() {
+        val ast = listOf(
+            PrintNode(minus(num(3.0), num(1.0))), // 2
+            PrintNode(star(num(2.0), num(5.0))),  // 10
+            PrintNode(slash(num(8.0), num(2.0))), // 4
+            PrintNode(plus(num(2.0), num(0.0)))   // 2
+        )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("2","10","4","2"), out.lines)
+    }
+
+    @Test
+    fun `concatena string+string`() {
+        val ast = listOf(
+            DeclarationNode("a", "string", str("ab")),
+            DeclarationNode("b", "string", str("cd")),
+            PrintNode(plus(id("a"), id("b"))) // abcd
+        )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("abcd"), out.lines)
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -21,13 +21,16 @@ class EvaluatorTest {
     }
 
     @Test
-    fun `concatenacion con string - hola + 2025 = hola2025`() {
-        val env = Environment()
-        val ev = Evaluator(env)
-        val expr = plus(str("hola"), num(2025.0))
-
-        val v = expr.accept(ev)
+    fun `string + string concatena - hola + 2025 = hola2025`() {
+        val v = plus(str("hola"), str("2025")).accept(Evaluator(Environment()))
         assertEquals(Value.Str("hola2025"), v)
+    }
+
+    @Test
+    fun `string + number lanza error en '+' estricto`() {
+        assertThrows(RuntimeError::class.java) {
+            plus(str("hola"), num(2025.0)).accept(Evaluator(Environment()))
+        }
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -1,0 +1,40 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.Value
+import org.printscript.interpreter.runtime.RuntimeError
+import org.printscript.interpreter.testutil.*
+
+class EvaluatorTest {
+
+    @Test
+    fun `suma y precedencia`() {
+        val env = Environment()
+        val ev = Evaluator(env)
+        val expr = plus(num(1.0), star(num(2.0), num(3.0)))
+
+        val v = expr.accept(ev)
+        assertEquals(Value.Num(7.0), v)
+    }
+
+    @Test
+    fun `concatenacion con string - hola + 2025 = hola2025`() {
+        val env = Environment()
+        val ev = Evaluator(env)
+        val expr = plus(str("hola"), num(2025.0))
+
+        val v = expr.accept(ev)
+        assertEquals(Value.Str("hola2025"), v)
+    }
+
+    @Test
+    fun `division por cero - lanza RuntimeError`() {
+        val env = Environment()
+        val ev = Evaluator(env)
+        val expr = slash(num(1.0), num(0.0))
+
+        assertThrows(RuntimeError::class.java) { expr.accept(ev) }
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -8,6 +8,7 @@ import org.printscript.interpreter.runtime.RuntimeError
 import org.printscript.interpreter.testutil.*
 
 class EvaluatorTest {
+    //expresiones - num, str, id, binary
 
     @Test
     fun `suma y precedencia`() {

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
@@ -2,18 +2,17 @@ package org.printscript.interpreter.eval
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.printscript.interpreter.io.OutputProvider
 import org.printscript.interpreter.runtime.Environment
 import org.printscript.interpreter.runtime.RType
 import org.printscript.interpreter.runtime.RuntimeError
 import org.printscript.interpreter.testutil.*
 import org.printscript.interpreter.ir.*
-import org.printscript.interpreter.io.OutputProvider
 
 class ExecutorTest {
-    //sentencias: decl, assign, print
 
     @Test
-    fun `declarar numero y printear resultado`() {
+    fun `declara x y lo imprime`() {
         val env = Environment()
         val out = object : OutputProvider {
             val lines = mutableListOf<String>()
@@ -21,6 +20,7 @@ class ExecutorTest {
         }
         val exec = Executor(env, out)
 
+        //x=1+2*3
         val prog = listOf<StmtIR>(
             decl("x", RType.NUMBER, plus(num(1.0), star(num(2.0), num(3.0)))), // 7
             print(id("x"))
@@ -33,10 +33,45 @@ class ExecutorTest {
     }
 
     @Test
+    fun `concatena string+string en println`() {
+        val env = Environment()
+        val out = object : OutputProvider {
+            val lines = mutableListOf<String>()
+            override fun println(text: String) { lines += text }
+        }
+        val exec = Executor(env, out)
+
+        val prog = listOf<StmtIR>(
+            decl("s", RType.STRING, str("hola")),
+            print(plus(id("s"), str("2025")))
+        )
+
+        prog.forEach { it.accept(exec) }
+
+        assertEquals(listOf("hola2025"), out.lines)
+        assertEquals(mapOf("s" to "hola"), env.snapshot())
+    }
+
+    @Test
+    fun `string + number en println falla (tipado estricto en '+')`() {
+        val env = Environment()
+        val exec = Executor(env, OutputProvider { /* no-op */ })
+
+        val prog = listOf<StmtIR>(
+            decl("s", RType.STRING, str("hola")),
+            print(plus(id("s"), num(2025.0)))
+        )
+
+        val ex = assertThrows(RuntimeError::class.java) {
+            prog.forEach { it.accept(exec) }
+        }
+        assertTrue(ex.message!!.contains("Operador '+' no definido"))
+    }
+
+    @Test
     fun `type mismatch en declaracion - falla`() {
         val env = Environment()
-        val out = OutputProvider { }
-        val exec = Executor(env, out)
+        val exec = Executor(env, OutputProvider { /* no-op */ })
 
         val prog = listOf<StmtIR>(
             decl("s", RType.STRING, num(10.0))
@@ -45,15 +80,13 @@ class ExecutorTest {
         val ex = assertThrows(IllegalArgumentException::class.java) {
             prog.forEach { it.accept(exec) }
         }
-        // El mensaje lo arma require(...) en Executor.visitDecl
         assertTrue(ex.message!!.contains("Inicialización incompatible"))
     }
 
     @Test
     fun `variable no definida - falla al asignar`() {
         val env = Environment()
-        val out = OutputProvider { }
-        val exec = Executor(env, out)
+        val exec = Executor(env, OutputProvider { /* no-op */ })
 
         val prog = listOf(assign("x", num(3.0)))
 

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
@@ -1,0 +1,65 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.RType
+import org.printscript.interpreter.runtime.RuntimeError
+import org.printscript.interpreter.testutil.*
+import org.printscript.interpreter.ir.*
+import org.printscript.interpreter.io.OutputProvider
+
+class ExecutorTest {
+    //sentencias: decl, assign, print
+
+    @Test
+    fun `declarar numero y printear resultado`() {
+        val env = Environment()
+        val out = object : OutputProvider {
+            val lines = mutableListOf<String>()
+            override fun println(text: String) { lines += text }
+        }
+        val exec = Executor(env, out)
+
+        val prog = listOf<StmtIR>(
+            decl("x", RType.NUMBER, plus(num(1.0), star(num(2.0), num(3.0)))), // 7
+            print(id("x"))
+        )
+
+        prog.forEach { it.accept(exec) }
+
+        assertEquals(listOf("7"), out.lines)
+        assertEquals(mapOf("x" to "7"), env.snapshot())
+    }
+
+    @Test
+    fun `type mismatch en declaracion - falla`() {
+        val env = Environment()
+        val out = OutputProvider { }
+        val exec = Executor(env, out)
+
+        val prog = listOf<StmtIR>(
+            decl("s", RType.STRING, num(10.0))
+        )
+
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            prog.forEach { it.accept(exec) }
+        }
+        // El mensaje lo arma require(...) en Executor.visitDecl
+        assertTrue(ex.message!!.contains("Inicialización incompatible"))
+    }
+
+    @Test
+    fun `variable no definida - falla al asignar`() {
+        val env = Environment()
+        val out = OutputProvider { }
+        val exec = Executor(env, out)
+
+        val prog = listOf(assign("x", num(3.0)))
+
+        val ex = assertThrows(RuntimeError::class.java) {
+            prog.forEach { it.accept(exec) }
+        }
+        assertTrue(ex.message!!.contains("Variable 'x' no definida"))
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
@@ -55,7 +55,7 @@ class ExecutorTest {
     @Test
     fun `string + number en println falla (tipado estricto en '+')`() {
         val env = Environment()
-        val exec = Executor(env, OutputProvider { /* no-op */ })
+        val exec = Executor(env) { /* no-op */ }
 
         val prog = listOf<StmtIR>(
             decl("s", RType.STRING, str("hola")),
@@ -71,7 +71,7 @@ class ExecutorTest {
     @Test
     fun `type mismatch en declaracion - falla`() {
         val env = Environment()
-        val exec = Executor(env, OutputProvider { /* no-op */ })
+        val exec = Executor(env) { /* no-op */ }
 
         val prog = listOf<StmtIR>(
             decl("s", RType.STRING, num(10.0))
@@ -86,7 +86,7 @@ class ExecutorTest {
     @Test
     fun `variable no definida - falla al asignar`() {
         val env = Environment()
-        val exec = Executor(env, OutputProvider { /* no-op */ })
+        val exec = Executor(env) { }
 
         val prog = listOf(assign("x", num(3.0)))
 

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/memory/BigProgramSmokeTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/memory/BigProgramSmokeTest.kt
@@ -1,0 +1,18 @@
+package org.printscript.interpreter.memory
+
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.eval.Executor
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.ir.*
+
+class BigProgramSmokeTest {
+
+    @Test
+    fun `10k prints with limited heap`() {
+        val exec = Executor(Environment()) { /* no-op output */ }
+
+        repeat(10_000) { i ->
+            PrintIR(NumLit(i.toDouble())).accept(exec)
+        }
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/memory/NoRetentionTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/memory/NoRetentionTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.printscript.interpreter.eval.Executor
-import org.printscript.interpreter.io.OutputProvider
 import org.printscript.interpreter.runtime.Environment
 import org.printscript.interpreter.runtime.RType
 import org.printscript.interpreter.ir.*
@@ -30,7 +29,7 @@ class NoRetentionTest {
 
     @Test
     fun `IR queda elegible para GC luego de ejecutar (phantom)`() {
-        val exec = Executor(Environment(), OutputProvider { })
+        val exec = Executor(Environment()) {}
 
         val (queue, phantom) = buildAndRunProgramPhantom(exec)
         keepAlive = phantom  // referencia fuerte para que no se GC la phantom

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/memory/NoRetentionTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/memory/NoRetentionTest.kt
@@ -1,0 +1,88 @@
+package org.printscript.interpreter.memory
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.printscript.interpreter.eval.Executor
+import org.printscript.interpreter.io.OutputProvider
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.RType
+import org.printscript.interpreter.ir.*
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+
+@Tag("memory")
+class NoRetentionTest {
+
+    // Mantiene viva la PhantomReference hasta el fin del test (evita GC de la referencia misma)
+    private var keepAlive: Any? = null
+
+    //en resumen, este test verifica que el IR no tenga referencias retenidas
+    // Verifica que el IR usado en una ejecución grande sea recolectado
+    // usando PhantomReference y ReferenceQueue.
+
+    // Construye y ejecuta un programa grande dentro de un scope
+    // que crea una PhantomReference al IR antes de salir del scope.
+    // Luego de salir del scope, fuerza GC y espera a que la PhantomReference
+    // sea encolada, lo que indica que el IR fue recolectado.
+    // Si no se encola en un tiempo razonable, es probable que haya retención
+    // de referencias al IR en alguna parte del Executor/Evaluator/Environment.
+
+    @Test
+    fun `IR queda elegible para GC luego de ejecutar (phantom)`() {
+        val exec = Executor(Environment(), OutputProvider { })
+
+        val (queue, phantom) = buildAndRunProgramPhantom(exec)
+        keepAlive = phantom  // referencia fuerte para que no se GC la phantom
+
+        val collected = waitEnqueued(queue) // usa valor por defecto (3s)
+        assertTrue(collected, "El IR sigue referenciado; posible retención")
+    }
+
+    private fun buildAndRunProgramPhantom(
+        exec: Executor
+    ): Pair<ReferenceQueue<Any>, PhantomReference<Any>> {
+        val queue = ReferenceQueue<Any>()
+        lateinit var phantom: PhantomReference<Any>
+
+        // Aisla 'prog' en este stack frame: al salir, no quedan refs fuertes
+        run {
+            val prog = ArrayList<StmtIR>(4000).apply {
+                // let v<i>: number = i;
+                repeat(2000) { i ->
+                    add(DeclIR("v$i", RType.NUMBER, NumLit(i.toDouble())))
+                }
+                // println(v<i>);
+                repeat(2000) { i ->
+                    add(PrintIR(IdRef("v$i")))
+                }
+            }
+
+            // Ejecutar el programa
+            prog.forEach { it.accept(exec) }
+
+            // Creamos la PhantomReference ANTES de salir del scope
+            @Suppress("UNCHECKED_CAST")
+            phantom = PhantomReference(prog as Any, queue)
+        }
+
+        return queue to phantom
+    }
+
+    /**
+     * Espera hasta que el GC encole la referencia (no determinístico).
+     * Reintenta con GC + sleep; 3s suele ser suficiente en CI.
+     */
+    private fun waitEnqueued(
+        queue: ReferenceQueue<Any>,
+        timeoutMs: Long = 3_000
+    ): Boolean {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (System.nanoTime() < deadline) {
+            System.gc()
+            if (queue.poll() != null) return true
+            Thread.sleep(20)
+        }
+        return false
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/runtime/EnvironmentTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/runtime/EnvironmentTest.kt
@@ -1,0 +1,25 @@
+package org.printscript.interpreter.runtime
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class EnvironmentTest {
+    @Test fun `declara y lee numero`() {
+        val env = Environment()
+        env.declare("a", RType.NUMBER, Value.Num(1.5))
+        assertEquals(Value.Num(1.5), env.read("a"))
+    }
+    @Test fun `asignar no crea nuevas entradas`() {
+        val env = Environment()
+        env.declare("a", RType.NUMBER, Value.Num(1.0))
+        env.assign("a", Value.Num(2.0)); env.assign("a", Value.Num(3.0))
+        assertEquals(setOf("a"), env.snapshot().keys)
+        assertEquals("3", env.snapshot()["a"])
+    }
+    @Test fun `usar antes de inicializar falla`() {
+        val env = Environment()
+        env.declare("x", RType.STRING, null)
+        val ex = assertThrows(RuntimeError::class.java) { env.read("x") }
+        assertTrue(ex.message!!.contains("antes de inicializar"))
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/testutil/BufferOutput.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/testutil/BufferOutput.kt
@@ -1,0 +1,8 @@
+package org.printscript.interpreter.testutil
+
+import org.printscript.interpreter.io.OutputProvider
+
+class BufferOutput : OutputProvider {
+    val lines = mutableListOf<String>()
+    override fun println(text: String) { lines += text }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/testutil/IrBuilders.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/testutil/IrBuilders.kt
@@ -1,0 +1,17 @@
+package org.printscript.interpreter.testutil
+
+import org.printscript.interpreter.ir.*
+import org.printscript.interpreter.runtime.RType
+
+fun num(v: Double) = NumLit(v)
+fun str(v: String) = StrLit(v)
+fun id(name: String) = IdRef(name)
+
+fun plus(l: ExprIR, r: ExprIR) = Binary(Op.PLUS, l, r)
+fun minus(l: ExprIR, r: ExprIR) = Binary(Op.MINUS, l, r)
+fun star(l: ExprIR, r: ExprIR) = Binary(Op.STAR, l, r)
+fun slash(l: ExprIR, r: ExprIR) = Binary(Op.SLASH, l, r)
+
+fun decl(name: String, type: RType, init: ExprIR) = DeclIR(name, type, init)
+fun assign(name: String, expr: ExprIR) = AssignIR(name, expr)
+fun print(expr: ExprIR) = PrintIR(expr)

--- a/lexer/src/test/kotlin/org/printscript/lexer/LexerHappyPathTest.kt
+++ b/lexer/src/test/kotlin/org/printscript/lexer/LexerHappyPathTest.kt
@@ -14,8 +14,6 @@ class LexerHappyPathTest {
         """.trimIndent()
 
         val tokens = Lexer().lex(code)
-
-        // ⚠️ Si en tu enum usás SEPARATOR en vez de COLON, cambiá COLON -> SEPARATOR aquí.
         val tiposEsperados = listOf(
             TokenType.LET,
             TokenType.IDENTIFIER,

--- a/parser/src/main/kotlin/Main.kt
+++ b/parser/src/main/kotlin/Main.kt
@@ -1,5 +1,0 @@
-package org.printscript
-
-fun main() {
-    println("Hello World!")
-}


### PR DESCRIPTION
## 📌 Resumen

Este PR agrega el módulo **`:interpreter`** para PrintScript, basado en una **Intermediate Representation (IR)** propia y **patrón Visitor**. Se introduce **tipado estricto** del operador `+`, un **OutputProvider** inyectable, un **Environment** de ejecución, manejo de **errores de runtime** y una **suite de tests** (unitarios, integración y memoria) enfocada en corrección y **no retención de memoria**.

---

## 🎯 Objetivos

* Desacoplar la ejecución del AST del parser mediante una IR.
* Asegurar diseño limpio y extensible para futuras fases (analyzer, formatter, CLI).
* Habilitar pruebas unitarias del intérprete sin depender de lexer/parser y, además, pruebas de integración con `node.*`.
* Validar **uso de memoria** (no retener IR/AST) y detectar leaks temprano.

---

## 🧱 Cambios por módulo / carpeta

**`:interpreter`**

* `api/Interpreter.kt`
  Orquestador. Recibe `List<node.ASTNode>`, transforma a IR y ejecuta. Permite inyectar `OutputProvider`. Expone `environmentSnapshot()` para tests/CLI.
* `ir/IrNodes.kt`
  IR del intérprete:

  * Sentencias: `DeclIR`, `AssignIR`, `PrintIR` (interface `StmtIR`).
  * Expresiones: `NumLit`, `StrLit`, `IdRef`, `Binary` (interface `ExprIR`).
  * `Op` (`PLUS`, `MINUS`, `STAR`, `SLASH`) y visitors (`ExprVisitor`, `StmtVisitor`).
* `transform/AstToIr.kt`
  Adaptador `node.*` → IR. Único punto que conoce el AST del parser.
* `eval/Evaluator.kt`
  Visitor de **expresiones**. `+` **estricto**: solo `number+number` y `string+string`. `- * /` requieren números. División por cero → `RuntimeError`.
* `eval/Executor.kt`
  Visitor de **sentencias**. Declaración valida tipo del inicializador; asignación valida existencia + tipo; `println` usa `OutputProvider` y formatea enteros sin “.0”.
* `runtime/RuntimeValues.kt`
  `Value.Num`, `Value.Str`, `RType` (**público**), helpers internos.
* `runtime/Environment.kt`
  Tabla de variables con `declare/assign/read`, validaciones y `snapshot()`. `Var` es **privada** para encapsular.
* `runtime/RuntimeError.kt`
  Excepción de ejecución.
* `io/OutputProvider.kt` + `io/DefaultOutputProvider.kt`
  Abstracción de salida; facilita testear `println` sin `System.out`.

**Gradle (`:interpreter`)**

* `implementation project(':parser')`
* Tests con JUnit 5 + heap limitado para smoke de memoria (`minHeapSize = "64m"`, `maxHeapSize = "128m"`).

> No se modifican `:lexer`, `:token` ni `:parser`. Solo se consume `node.*` en el adaptador.

---

## 📐 Semántica implementada

* **Operadores**

  * `+` **estricto**: `number+number` → suma; `string+string` → concat.
    Otras combinaciones → `RuntimeError("Operador '+' no definido…")`.
  * `-`, `*`, `/` requieren números; `/` con 0 → `RuntimeError("División por cero")`.
* **Variables**

  * Declaración con tipo y valor inicial (para quedar inicializada).
  * Leer no declarada → `RuntimeError`.
  * Leer declarada no inicializada → `RuntimeError`.
  * Re-declaración → `RuntimeError`.
  * Asignación con tipo incompatible → `RuntimeError`.
* **println**

  * Números enteros se imprimen sin “.0”.
  * Strings se imprimen como están.

---

## 🧠 Decisiones de diseño (pros / contras)

* **IR + Adapter (AstToIr)**

  * ✅ Desacople del parser; cambios en parser solo tocan el adaptador; permite reutilizar IR en analyzer/formatter; unit tests del intérprete no dependen de lexer/parser.
  * ⚠️ Un archivo y paso extra (transformación).
* **Patrón Visitor**

  * ✅ Separa estructura (IR) de operaciones (evaluar/ejecutar); agregar nuevas operaciones no rompe nodos; testeo granular.
  * ⚠️ Más clases/interfaces y pequeña curva de aprendizaje.
* **OutputProvider inyectable**

  * ✅ Tests de `println` sin IO real; inyección sencilla (lambda SAM).
  * ⚠️ Otro parámetro a inyectar (costo mínimo).
* **Tipado estricto en `+`**

  * ✅ Semántica clara; sin coerciones implícitas; el analyzer podrá detectarlo temprano.
  * ⚠️ Concatenar requiere `string + string` (p. ej., `"2025"` en vez de `2025`).

---

## 🧪 Tests agregados

**Unit (sobre IR)**

* `EvaluatorTest`: aritmética; concat string+string; error string+number; división por cero.
* `ExecutorTest`: declaración/print; concat en `println`; mismatch en declaración; asignación a no declarada.
* `EnvironmentTest`: declarar/leer; asignar sin duplicar entrada; leer sin inicializar.

**Integración (con `node.*` del parser → Adapter → Interpreter)**

* **Happy Path IT**: precedencia `1 + 2 * 3`, concat `"hola" + "2025"`, reasignación `x = x + 1`, orden de impresión.
* **Errores IT**: `string + number`, división por cero, identificador no declarado, mismatch en declaración/asignación.
* **Edge Cases IT**: enteros sin “.0”; precedencia forzada con AST anidado.

**Memoria**

* **NoRetentionTest (phantom)**: usa `PhantomReference + ReferenceQueue` para verificar que el IR queda coleccionable tras la ejecución (sin `runFinalization`, deprecado).
* **BigProgramSmokeTest**: 10k `println` con heap limitado para detectar leaks burdos.

> ITs etiquetados con `@Tag("integration")` y/o sufijo `*IT`. Si el repo usa `sourceSet` separado para IT, la tarea `integrationTest` está lista para integrarse.

---

## 🧪 Cómo probar localmente

```bash
# Unit tests
./gradlew :interpreter:test

# Integration tests (si hay tarea separada)
./gradlew :interpreter:integrationTest

# Todo (incluye smoke de memoria con heap limitado)
./gradlew :interpreter:check
```

---

## ⚠️ Riesgos y mitigaciones

* **Fragilidad de tests de GC** (no determinísticos)
  → Se usa `PhantomReference + ReferenceQueue` y polling con timeout.
* **Cambios futuros en el parser**
  → Aislados en `AstToIr`. El intérprete y sus tests no cambian.

---

## 🔁 Rollback

* Revertir el commit del módulo `:interpreter` y entradas asociadas en `settings.gradle` / `build.gradle` si aplica.
* No se tocaron contratos públicos de otros módulos.

---

## 📎 Checklist

* [x] IR + visitors implementados
* [x] Adapter AST→IR (`AstToIr`)
* [x] Tipado estricto de `+`
* [x] OutputProvider inyectable
* [x] Environment con validaciones y `snapshot()`
* [x] RuntimeError con mensajes claros
* [x] Unit tests (eval, exec, env)
* [x] Integration tests (happy path, errores, edge)
* [x] Memory tests (phantom + smoke)
* [x] Gradle: JUnit 5 + heap limitado en tests
* [x] Documentación de decisiones en este PR

---

## 🔮 Próximos pasos (no incluidos)

* **Diagnostics** unificados por fase (lexer/parser/interpreter) y mapeo de excepciones a `Diagnostic`.
* **Scopes**/shadowing si la versión 1.1 introduce bloques.
* **Analyzer** estático sobre la misma IR.
* **CLI** que consuma `Interpreter` y muestre diagnostics.
* **E2E** con `Lexer + Parser + Interpreter` en un módulo de sistema/CLI.
