### PR TITLE
feat: Add GitHub Actions workflow for package publishing and update G…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish packages
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      -   uses: actions/checkout@v2
+
+      -   name: Set up JDK
+          uses: actions/setup-java@v3
+          with:
+            distribution: 'temurin'
+            java-version: '21'
+
+      -   name: Build with Gradle
+          run: ./gradlew build
+
+      - name: Set up Git user
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Release (version/tag auto)
+        run: ./gradlew release -Prelease.disableChecks=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Github Packages
+        run: ./gradlew publish
+        env:
+          GITHUB_ACTOR: ${{ env.GITHUB_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,19 @@
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
-plugins { }
+plugins {
+    id("pl.allegro.tech.build.axion-release") version "1.15.4"
+}
 
 group = "org.printscript"
-version = "1.0-SNAPSHOT"
+
+scmVersion {
+    tag {
+        prefix = "v"
+    }
+}
+
+project.version = scmVersion.version
 
 allprojects {
     repositories { mavenCentral() }


### PR DESCRIPTION

This pull request introduces a new GitHub Actions workflow to automate the publishing process for packages when changes are pushed to the `main` branch. The workflow includes steps for building, releasing, and publishing packages using Gradle, and sets up the necessary environment and permissions.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/publish.yml` to automatically build, release, and publish packages on pushes to the `main` branch using GitHub Actions. The workflow sets up the JDK, configures Git, and runs Gradle tasks for build, release, and publish, with appropriate permissions and environment variables.