### PR TITLE
feat: Update build configuration and GitHub Actions workflow for Mave…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Build and Test
         run: ./gradlew build
+      - name: Run Lint (Spotless)
+        run: ./gradlew spotlessCheck
       - name: Run Lint
         run: ./gradlew lint
       - name: Check coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v2
+        uses: gradle/gradle-build-action@v2
       - name: Build and Test
         run: ./gradlew build
       - name: Run Lint
         run: ./gradlew lint
       - name: Check coverage
         run: ./gradlew jacocoTestReport
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,14 +11,14 @@ jobs:
       packages: write
 
     steps:
-      -   name: Checkout repository
-          uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      -   name: Set up JDK
-          uses: actions/setup-java@v3
-          with:
-            distribution: 'temurin'
-            java-version: '21'
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
       - name: Build with Gradle
         run: ./gradlew build
@@ -28,13 +28,16 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
+      - name: Set up Git credentials
+        run: git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/Ingenieria-de-Sistemas-123/PrintScript.git
+
       - name: Release (version/tag auto)
         run: ./gradlew release -Prelease.disableChecks=true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Publish to GitHub Packages
         run: ./gradlew publish
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: Set up Git credentials
-        run: git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/Ingenieria-de-Sistemas-123/PrintScript.git
+        run: git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git
 
       - name: Release (version/tag auto)
         run: ./gradlew release -Prelease.disableChecks=true

--- a/buildSrc/src/main/kotlin/org.printscript.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.printscript.conventions.gradle.kts
@@ -106,7 +106,7 @@ tasks.named("check") {
     dependsOn("spotlessCheck", "jacocoTestReport", "jacocoTestCoverageVerification")
 }
 
-// === Publicación Maven para todos los módulos ===
+// === Maven publication for all modules ===
 plugins.withId("maven-publish") {
     extensions.configure<PublishingExtension> {
         publications {

--- a/token/build.gradle
+++ b/token/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'org.printscript.conventions'
 }
 
+group = 'org.printscript'
+version = '1.0-SNAPSHOT'
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
This pull request introduces several improvements to the build and release process, focusing on enhanced GitHub authentication, improved configuration clarity, and standardization of module metadata. The most significant changes include updating the GitHub Actions workflow to use a personal access token, clarifying comments in the Gradle build configuration, and explicitly setting group and version information for the `token` module.

**Build and Release Pipeline Improvements:**

* Updated the `.github/workflows/publish.yml` workflow to use a GitHub personal access token (`GH_PAT`) for authentication and set up Git credentials before release and publishing steps. This replaces the default `GITHUB_TOKEN` and ensures smoother publishing to GitHub Packages.

**Configuration and Documentation Enhancements:**

* Translated and clarified a comment in `org.printscript.conventions.gradle.kts` from Spanish to English to improve maintainability and understanding for non-Spanish speakers.

**Module Metadata Standardization:**

* Added explicit `group` and `version` properties to the `token/build.gradle` file, setting the group to `'org.printscript'` and the version to `'1.0-SNAPSHOT'` for consistent artifact identification.