### PR TITLE
refactor: Remove automatic release step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,6 @@ jobs:
       - name: Set up Git credentials
         run: git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git
 
-      - name: Release (version/tag auto)
-        run: ./gradlew release -Prelease.disableChecks=true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-
       - name: Publish to GitHub Packages
         run: ./gradlew publish
         env:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow by removing the automated release step. The workflow will now only publish to GitHub Packages without performing a version or tag release.