### PR TITLE
chore: Update project version to 1.1-SNAPSHOT in build.gradle

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories { mavenCentral() }
 

--- a/linter/build.gradle
+++ b/linter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/token/build.gradle
+++ b/token/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This pull request updates the project version from 1.0-SNAPSHOT to 1.1-SNAPSHOT across all module `build.gradle` files to reflect a new development iteration.

Version bump across all modules:

* Updated the `version` field from `1.0-SNAPSHOT` to `1.1-SNAPSHOT` in the following `build.gradle` files: `cli`, `common`, `formatter`, `interpreter`, `lexer`, `linter`, `parser`, and `token`. [[1]](diffhunk://#diff-de8fe44d5ac06e1637fb405beaa31259f0a95163399c0f8cb4158c820b9efcd0L7-R7) [[2]](diffhunk://#diff-824c1e8ad11e20caed0bec7162a99779b9a4bcf1178d99fae3e39f69889f8959L6-R6) [[3]](diffhunk://#diff-0c3ea61c5b5baf8c519b190b1677556d77f5ee6b9116749aeb9b35b37e0bb951L6-R6) [[4]](diffhunk://#diff-c4a5399386ce09562085a1d203d679cfe83aa4c5ab884612507e7a4431d76d4cL6-R6) [[5]](diffhunk://#diff-a987f7f97a40ffbdc40de50df8d383d102d853765aae36fdbb34c1d1ad45ed77L6-R6) [[6]](diffhunk://#diff-8f5ee92674fa0501f08ebe4f36e7e5103580e399afe9b58928e39d4a34cbfd56L6-R6) [[7]](diffhunk://#diff-53f6c389782d522fe2b4261a33097ef3edf5fd06b0ae4191a7e603d2642119d7L6-R6) [[8]](diffhunk://#diff-3e639a6da9adc9cc49c9ecba85bd6075c1aeaabe1510d5d339525caf3cc7ad9fL6-R6)