### PR TITLE
Version test

### DIFF
--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.2-SNAPSHOT'
+version = '1.3-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.1-SNAPSHOT'
+version = '1.2-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
@@ -31,18 +31,23 @@ internal class Evaluator(
     // v1.1
     override fun visitBool(b: BoolLit): Value = Bool(b.value)
 
+    private fun numToString(n: Double): String =
+        if (n % 1.0 == 0.0) n.toInt().toString() else n.toString()
+
     override fun visitBinary(b: Binary): Value {
         val l = b.left.accept(this)
         val r = b.right.accept(this)
         return when (b.op) {
             Op.PLUS ->
                 when {
-                    l is Num && r is Num -> Num(l.v + r.v) // suma
-                    l is Str && r is Str -> Str(l.v + r.v) // concat
+                    l is Num && r is Num -> Num(l.v + r.v)
+                    l is Str && r is Str -> Str(l.v + r.v)
+                    l is Str && r is Num -> Str(l.v + numToString(r.v))
+                    l is Num && r is Str -> Str(numToString(l.v) + r.v)
                     else -> throw RuntimeError(
-                        "Operador '+' no definido para ${typeName(l)} y ${typeName(r)}",
-                    )
-                }
+                    "Operador '+' no definido para ${typeName(l)} y ${typeName(r)}"
+                )
+            }
             Op.MINUS -> Num(reqNum(l, "-") - reqNum(r, "-"))
             Op.STAR -> Num(reqNum(l, "*") * reqNum(r, "*"))
             Op.SLASH -> {
@@ -52,6 +57,7 @@ internal class Evaluator(
             }
         }
     }
+
 
     // v1.1: readInput
     override fun visitReadInput(r: ReadInputIR): Value {

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
@@ -31,8 +31,7 @@ internal class Evaluator(
     // v1.1
     override fun visitBool(b: BoolLit): Value = Bool(b.value)
 
-    private fun numToString(n: Double): String =
-        if (n % 1.0 == 0.0) n.toInt().toString() else n.toString()
+    private fun numToString(n: Double): String = if (n % 1.0 == 0.0) n.toInt().toString() else n.toString()
 
     override fun visitBinary(b: Binary): Value {
         val l = b.left.accept(this)
@@ -45,9 +44,9 @@ internal class Evaluator(
                     l is Str && r is Num -> Str(l.v + numToString(r.v))
                     l is Num && r is Str -> Str(numToString(l.v) + r.v)
                     else -> throw RuntimeError(
-                    "Operador '+' no definido para ${typeName(l)} y ${typeName(r)}"
-                )
-            }
+                        "Operador '+' no definido para ${typeName(l)} y ${typeName(r)}",
+                    )
+                }
             Op.MINUS -> Num(reqNum(l, "-") - reqNum(r, "-"))
             Op.STAR -> Num(reqNum(l, "*") * reqNum(r, "*"))
             Op.SLASH -> {
@@ -57,7 +56,6 @@ internal class Evaluator(
             }
         }
     }
-
 
     // v1.1: readInput
     override fun visitReadInput(r: ReadInputIR): Value {

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
@@ -2,6 +2,7 @@ package org.printscript.interpreter
 
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -14,15 +15,15 @@ import org.printscript.parser.node.PrintNode
 @DisplayName("Interpreter – Errores")
 class InterpreterErrorsIT : BaseInterpreterIT() {
     @Test
-    fun `string + number falla ( '+' estricto )`() {
+    fun `string + number concatena correctamente`() {
         val ast =
             listOf(
                 DeclarationNode("s", "string", str("hola"), pos()),
                 PrintNode(plus(id("s"), num(2025.0)), pos()),
             )
-        val (interpreter, _) = newInterpreterWithBuffer()
-        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
-        assertTrue(ex.message!!.contains("Operador '+' no definido"))
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("hola2025"), out.lines)
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterErrorsIT.kt
@@ -2,7 +2,6 @@ package org.printscript.interpreter
 
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -23,7 +22,7 @@ class InterpreterErrorsIT : BaseInterpreterIT() {
             )
         val (interpreter, out) = newInterpreterWithBuffer()
         interpreter.execute(ast)
-        assertEquals(listOf("hola2025"), out.lines)
+        assertTrue { out.lines == listOf("hola2025") }
     }
 
     @Test
@@ -68,5 +67,25 @@ class InterpreterErrorsIT : BaseInterpreterIT() {
         val (interpreter, _) = newInterpreterWithBuffer()
         val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
         assertTrue(ex.message!!.contains("Asignación incompatible"))
+    }
+
+    @Test
+    fun `declaracion doble de variable`() {
+        val ast =
+            listOf(
+                DeclarationNode("x", "number", num(1.0), pos()),
+                DeclarationNode("x", "number", num(2.0), pos()),
+            )
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(RuntimeError::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Variable 'x' ya definida"))
+    }
+
+    @Test
+    fun `declaracion con tipo invalido - falla`() {
+        val ast = listOf(DeclarationNode("x", "boolean", num(1.0), pos()))
+        val (interpreter, _) = newInterpreterWithBuffer()
+        val ex = assertThrows(IllegalStateException::class.java) { interpreter.execute(ast) }
+        assertTrue(ex.message!!.contains("Tipo de declaración desconocido 'boolean'"))
     }
 }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.printscript.parser.node.AssignationNode
 import org.printscript.parser.node.DeclarationNode
 import org.printscript.parser.node.PrintNode
+import kotlin.text.lines
 
 @Tag("integration")
 @DisplayName("Interpreter – Happy Path")
@@ -53,4 +54,17 @@ class InterpreterHappyPathIT : BaseInterpreterIT() {
         interpreter.execute(ast)
         assertEquals(listOf("abcd"), out.lines)
     }
+
+    @Test
+    fun `concatena string+number`() {
+        val ast =
+            listOf(
+                DeclarationNode("s", "string", str("hola"), pos()),
+                PrintNode(plus(id("s"), num(2025.0)), pos()),
+            )
+        val (interpreter, out) = newInterpreterWithBuffer()
+        interpreter.execute(ast)
+        assertEquals(listOf("hola2025"), out.lines)
+    }
+
 }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.printscript.parser.node.AssignationNode
 import org.printscript.parser.node.DeclarationNode
 import org.printscript.parser.node.PrintNode
-import kotlin.text.lines
 
 @Tag("integration")
 @DisplayName("Interpreter – Happy Path")

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -65,5 +65,4 @@ class InterpreterHappyPathIT : BaseInterpreterIT() {
         interpreter.execute(ast)
         assertEquals(listOf("hola2025"), out.lines)
     }
-
 }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ConstDeclTypeMismatchTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ConstDeclTypeMismatchTest.kt
@@ -1,0 +1,20 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.ir.ConstDeclIR
+import org.printscript.interpreter.ir.StrLit
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.RType
+import org.printscript.interpreter.util.TestIO
+
+class ConstDeclTypeMismatchTest {
+    @Test fun `const con tipo incompatible lanza IllegalArgumentException`() {
+        val env = Environment()
+        val exec = Executor(env, { }, TestIO.empty)
+        val prog = listOf(ConstDeclIR("c", RType.NUMBER, StrLit("oops")))
+        val ex = assertThrows(IllegalArgumentException::class.java) { exec.exec(prog) }
+        assertTrue(ex.message!!.contains("Inicialización incompatible"))
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -7,6 +7,7 @@ import org.printscript.interpreter.runtime.Environment
 import org.printscript.interpreter.runtime.RuntimeError
 import org.printscript.interpreter.runtime.Value
 import org.printscript.interpreter.util.TestIO
+import org.printscript.interpreter.util.minus
 import org.printscript.interpreter.util.num
 import org.printscript.interpreter.util.plus
 import org.printscript.interpreter.util.slash
@@ -33,10 +34,23 @@ class EvaluatorTest {
     }
 
     @Test
-    fun `string + number lanza error en '+' estricto`() {
-        assertThrows(RuntimeError::class.java) {
-            plus(str("hola"), num(2025.0)).accept(Evaluator(Environment(), TestIO.empty))
-        }
+    fun `string + number concatena correctamente`() {
+        val v = plus(str("hola"), num(2025.0)).accept(Evaluator(Environment(), TestIO.empty))
+        assertEquals(Value.Str("hola2025"), v)
+    }
+
+    @Test
+    fun `number + string concatena correctamente`() {
+        val v = plus(num(2025.0), str("hola")).accept(Evaluator(Environment(), TestIO.empty))
+        assertEquals(Value.Str("2025hola"), v)
+    }
+
+    @Test
+    fun `resta con tipos no numericos falla`() {
+        val env = Environment()
+        val ev = Evaluator(env, TestIO.empty)
+        val expr = minus(str("1"), str("2"))
+        assertThrows(RuntimeError::class.java) { expr.accept(ev) }
     }
 
     @Test
@@ -46,5 +60,14 @@ class EvaluatorTest {
         val expr = slash(num(1.0), num(0.0))
 
         assertThrows(RuntimeError::class.java) { expr.accept(ev) }
+    }
+
+    @Test
+    fun `division normal - 8 div 2 = 4`() {
+        val env = Environment()
+        val ev = Evaluator(env, TestIO.empty)
+        val expr = slash(num(8.0), num(2.0))
+        val v = expr.accept(ev)
+        assertEquals(Value.Num(4.0), v)
     }
 }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
@@ -71,21 +71,25 @@ class ExecutorTest {
     }
 
     @Test
-    fun `string + number en println falla (tipado estricto en '+')`() {
+    fun `string + number concatena correctamente en println`() {
         val env = Environment()
-        val exec = Executor(env, { }, TestIO.empty)
+        val out =
+            object : OutputProvider {
+                val lines = mutableListOf<String>()
 
+                override fun println(text: String) {
+                    lines += text
+                }
+            }
+        val exec = Executor(env, out, TestIO.empty)
         val prog =
             listOf<StmtIR>(
                 decl("s", RType.STRING, str("hola")),
                 print(plus(id("s"), num(2025.0))),
             )
-
-        val ex =
-            assertThrows(RuntimeError::class.java) {
-                prog.forEach { it.accept(exec) }
-            }
-        assertTrue(ex.message!!.contains("Operador '+' no definido"))
+        prog.forEach { it.accept(exec) }
+        assertEquals(listOf("hola2025"), out.lines)
+        assertEquals(mapOf("s" to "hola"), env.snapshot())
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/IfElseErrorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/IfElseErrorTest.kt
@@ -1,0 +1,36 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.ir.DeclIR
+import org.printscript.interpreter.ir.IfIR
+import org.printscript.interpreter.ir.NumLit
+import org.printscript.interpreter.ir.PrintIR
+import org.printscript.interpreter.ir.StrLit
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.RType
+import org.printscript.interpreter.runtime.RuntimeError
+import org.printscript.interpreter.util.TestIO
+
+class IfElseErrorTest {
+    @Test fun `if con condicion no booleana falla`() {
+        val env = Environment()
+        val exec = Executor(env, { }, TestIO.empty)
+        val prog =
+            listOf(
+                DeclIR("b", RType.NUMBER, NumLit(1.0)),
+                IfIR("b", listOf(PrintIR(StrLit("then"))), listOf(PrintIR(StrLit("else")))),
+            )
+        val ex = assertThrows(RuntimeError::class.java) { exec.exec(prog) }
+        assertTrue(ex.message!!.contains("boolean"))
+    }
+
+    @Test fun `if con variable inexistente falla`() {
+        val env = Environment()
+        val exec = Executor(env, { }, TestIO.empty)
+        val prog = listOf(IfIR("nope", listOf(PrintIR(StrLit("x"))), null))
+        val ex = assertThrows(RuntimeError::class.java) { exec.exec(prog) }
+        assertTrue(ex.message!!.contains("no definida"))
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ReadEnvDefaultsTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ReadEnvDefaultsTest.kt
@@ -1,0 +1,22 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.ir.PrintIR
+import org.printscript.interpreter.ir.ReadEnvIR
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.util.CapturingOutput
+import org.printscript.interpreter.util.MapEnvProvider
+import org.printscript.interpreter.util.TestIO
+
+class ReadEnvDefaultsTest {
+    @Test fun `readEnv default string imprime literal`() {
+        val env = Environment()
+        val out = CapturingOutput()
+        val io = TestIO.empty.copy(env = MapEnvProvider(mapOf("GREETING" to "hola")))
+        val exec = Executor(env, out, io)
+        val prog = listOf(PrintIR(ReadEnvIR("GREETING", expected = null)))
+        exec.exec(prog)
+        assertEquals(listOf("hola"), out.lines)
+    }
+}

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ReadInputDefaultsTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ReadInputDefaultsTest.kt
@@ -1,0 +1,31 @@
+package org.printscript.interpreter.eval
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.printscript.interpreter.ir.PrintIR
+import org.printscript.interpreter.ir.ReadInputIR
+import org.printscript.interpreter.runtime.Environment
+import org.printscript.interpreter.runtime.RuntimeError
+import org.printscript.interpreter.util.CapturingOutput
+import org.printscript.interpreter.util.QueueInputProvider
+import org.printscript.interpreter.util.TestIO
+
+class ReadInputDefaultsTest {
+    @Test fun `readInput default string imprime literal`() {
+        val env = Environment()
+        val out = CapturingOutput()
+        val io = TestIO.empty.copy(input = QueueInputProvider(listOf("hola")))
+        val exec = Executor(env, out, io)
+        val prog = listOf(PrintIR(ReadInputIR("?", expected = null)))
+        exec.exec(prog)
+        assertEquals(listOf("hola"), out.lines)
+    }
+
+    @Test fun `readInput sin entrada lanza error`() {
+        val env = Environment()
+        val exec = Executor(env, { }, TestIO.empty) // input devuelve null
+        val prog = listOf(PrintIR(ReadInputIR("?", expected = null)))
+        assertThrows(RuntimeError::class.java) { exec.exec(prog) }
+    }
+}


### PR DESCRIPTION
This pull request updates the interpreter to support concatenation of strings and numbers using the `+` operator, instead of throwing a runtime error. It also includes new and updated tests to verify this behavior. Additionally, the project version is incremented.

Interpreter enhancements:

* Modified the `Evaluator` class to allow concatenation of `String` and `Number` operands with the `+` operator, converting numbers to strings as needed.
* Added a helper function `numToString` in `Evaluator` to handle number-to-string conversion for concatenation.

Testing improvements:

* Updated the test `string + number` to expect correct concatenation instead of a runtime error in `InterpreterErrorsIT.kt`.
* Added a new happy path test for string and number concatenation in `InterpreterHappyPathIT.kt`.
* Added necessary test assertion imports.

Versioning:

* Bumped project version from `1.1-SNAPSHOT` to `1.2-SNAPSHOT` in `build.gradle`.