### PR TITLE
feat: Update version to 1.4-SNAPSHOT and enhance number parsing in As…

### DIFF
--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.3-SNAPSHOT'
+version = '1.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/adapter/AstToIr.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/adapter/AstToIr.kt
@@ -86,7 +86,9 @@ class AstToIr : AstToIrMapper {
     private fun numberFromAny(v: Any?): Double =
         when (v) {
             is Number -> v.toDouble()
-            is String -> v.toDoubleOrNull() ?: error("Literal number inválido: '$v'")
+            is String ->
+                v.toDoubleOrNull()
+                    ?: if (v == "empty") 0.0 else error("Literal number inválido: '$v'")
             else -> error("Literal number inválido: $v")
         }
 }


### PR DESCRIPTION

This pull request includes a version bump for the project and an improvement to how string values are converted to numbers in the AST-to-IR mapping logic. The most notable change is that the string value "empty" is now interpreted as 0.0 instead of causing an error.

Versioning:

* Updated the project version from `1.3-SNAPSHOT` to `1.4-SNAPSHOT` in `build.gradle` to reflect new changes.

AST-to-IR mapping improvements:

* Modified `AstToIr.kt` so that when converting a string to a number, the string "empty" is now mapped to `0.0` instead of throwing an error. Other invalid strings still result in an error.