### PR TITLE
chore: Bump version to 1.2-SNAPSHOT and add JvmField annotations in P…

### DIFF
--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.1-SNAPSHOT'
+version = '1.2-SNAPSHOT'
 
 repositories { mavenCentral() }
 

--- a/lexer/src/main/kotlin/org/printscript/lexer/pattern/PreConfiguredTokens.kt
+++ b/lexer/src/main/kotlin/org/printscript/lexer/pattern/PreConfiguredTokens.kt
@@ -3,6 +3,7 @@ package org.printscript.lexer.pattern
 import org.printscript.token.TokenType
 
 object PreConfiguredTokens {
+    @JvmField
     val TOKENS_1_0: TokenProvider =
         TokenProvider builder (
             mapOf(
@@ -22,6 +23,7 @@ object PreConfiguredTokens {
             )
         )
 
+    @JvmField
     val TOKENS_1_1: TokenProvider =
         TokenProvider.builder(
             mapOf(


### PR DESCRIPTION
This pull request updates the lexer module to support new features and improve interoperability. The main changes include bumping the version, and adding `@JvmField` annotations to key token provider fields for easier Java interop.

Versioning update:

* Updated the project version from `'1.1-SNAPSHOT'` to `'1.2-SNAPSHOT'` in `lexer/build.gradle` to reflect new changes and features.

Java interoperability improvements:

* Added `@JvmField` annotation to the `TOKENS_1_0` and `TOKENS_1_1` fields in `PreConfiguredTokens.kt`, making them accessible as static fields from Java code. [[1]](diffhunk://#diff-0633364706ea44b8e77dbf96ff4c1e601f60a5fa83dd579359aa79d0c8e697b9R6) [[2]](diffhunk://#diff-0633364706ea44b8e77dbf96ff4c1e601f60a5fa83dd579359aa79d0c8e697b9R26)