### PR TITLE
fix: Remove newline characters from output assertions from print outp…

### DIFF
--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.8-SNAPSHOT'
+version = '1.9-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
@@ -40,7 +40,7 @@ internal class Executor(
 
     override fun visitPrint(p: PrintIR) {
         when (val v = p.expr.accept(eval)) {
-            is Value.Num, is Value.Str -> output.println(v.asString() + "\n")
+            is Value.Num, is Value.Str -> output.println(v.asString())
             else -> throw RuntimeError("println solo acepta valores de tipo number o string")
         }
     }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -30,7 +30,7 @@ class InterpreterHappyPathIT : BaseInterpreterIT() {
         val (interpreter, out) = newInterpreterWithBuffer()
         interpreter.execute(ast)
         assertEquals(listOf("7", "hola!2025", "8"), out.lines)
-        assertEquals(listOf("7\n", "hola!2025\n", "8\n"), out.raw)
+        assertEquals(listOf("7", "hola!2025", "8"), out.raw)
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/adapter/AdapterSmokeTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/adapter/AdapterSmokeTest.kt
@@ -54,7 +54,7 @@ class AdapterSmokeTest {
         val exec = Executor(Environment(), { out.append(it) }, TestIO.empty)
         ir.forEach { it.accept(exec) }
 
-        assertEquals("3\n", out.toString())
+        assertEquals("3", out.toString())
     }
 
     @Test
@@ -85,7 +85,7 @@ class AdapterSmokeTest {
         val exec = Executor(Environment(), { out.append(it) }, TestIO.empty)
         ir.forEach { it.accept(exec) }
 
-        assertEquals("Si\nSiempre\n", out.toString())
+        assertEquals("SiSiempre", out.toString())
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -134,7 +134,7 @@ class EvaluatorTest {
         val executor = Executor(env, { s: String -> output += s }, TestIO.empty)
         val printStmt = PrintIR(NumLit(7.0))
         printStmt.accept(executor)
-        assertEquals("7\n", output)
+        assertEquals("7", output)
     }
 
     @Test

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/ExecutorTest.kt
@@ -35,7 +35,7 @@ class ExecutorTest {
         prog.forEach { it.accept(exec) }
 
         assertEquals(listOf("7"), out.lines)
-        assertEquals(listOf("7\n"), out.raw)
+        assertEquals(listOf("7"), out.raw)
         assertEquals(mapOf("x" to "7"), env.snapshot())
     }
 
@@ -54,7 +54,7 @@ class ExecutorTest {
         prog.forEach { it.accept(exec) }
 
         assertEquals(listOf("hola2025"), out.lines)
-        assertEquals(listOf("hola2025\n"), out.raw)
+        assertEquals(listOf("hola2025"), out.raw)
         assertEquals(mapOf("s" to "hola"), env.snapshot())
     }
 
@@ -72,7 +72,7 @@ class ExecutorTest {
 
         prog.forEach { it.accept(exec) }
 
-        assertEquals(listOf("hola2025\n"), out)
+        assertEquals(listOf("hola2025"), out)
     }
 
     @Test

--- a/runner/build.gradle
+++ b/runner/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.3-SNAPSHOT'
+version = '1.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/runner/src/test/kotlin/org/printscript/runner/RunnerIOTest.kt
+++ b/runner/src/test/kotlin/org/printscript/runner/RunnerIOTest.kt
@@ -36,7 +36,7 @@ class RunnerIOTest {
         val stream = requireNotNull(javaClass.getResourceAsStream("/programs/v1_1/read-env.ps"))
         stream.use { runner.run(it) }
 
-        assertEquals(listOf(System.getenv("USER")?.plus("\n") ?: "\n"), output)
+        assertEquals(listOf(System.getenv("USER")?.plus("") ?: ""), output)
     }
 
     @Test
@@ -54,6 +54,6 @@ class RunnerIOTest {
         val stream = requireNotNull(javaClass.getResourceAsStream("/programs/v1_1/read-input.ps"))
         stream.use { runner.run(it) }
 
-        assertEquals(listOf("Ada\n"), output)
+        assertEquals(listOf("Ada"), output)
     }
 }

--- a/runner/src/test/kotlin/org/printscript/runner/RunnerTest.kt
+++ b/runner/src/test/kotlin/org/printscript/runner/RunnerTest.kt
@@ -33,7 +33,7 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("Hola mundo\n"), capturedOutput)
+        assertEquals(listOf("Hola mundo"), capturedOutput)
     }
 
     @Test
@@ -57,7 +57,7 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("Hola\n", "Hola!\n"), capturedOutput)
+        assertEquals(listOf("Hola", "Hola!"), capturedOutput)
     }
 
     @Test
@@ -82,7 +82,7 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("7\n", "3\n"), capturedOutput)
+        assertEquals(listOf("7", "3"), capturedOutput)
     }
 
     @Test
@@ -106,7 +106,7 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("true\n", "done\n"), capturedOutput)
+        assertEquals(listOf("true", "done"), capturedOutput)
     }
 
     @Test
@@ -153,7 +153,7 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("Hola!\n"), capturedOutput)
+        assertEquals(listOf("Hola!"), capturedOutput)
     }
 
     @Test
@@ -177,6 +177,6 @@ class RunnerTest {
             ),
             interpreter.environmentSnapshot(),
         )
-        assertEquals(listOf("Chau\n"), capturedOutput)
+        assertEquals(listOf("Chau"), capturedOutput)
     }
 }


### PR DESCRIPTION
This pull request updates the version numbers for both the interpreter and runner modules and standardizes the output of print statements by removing trailing newline characters. All relevant tests have been updated to match the new output format.

**Version updates:**
- Bumped `interpreter` module version to `1.9-SNAPSHOT` in `build.gradle`.
- Bumped `runner` module version to `1.4-SNAPSHOT` in `build.gradle`.

**Print output behavior:**
- Modified the `Executor` so that print statements no longer append a newline character to the output.

**Test updates for output changes:**

*Interpreter tests:*
- Updated assertions in `InterpreterHappyPathIT`, `ExecutorTest`, `EvaluatorTest`, and `AdapterSmokeTest` to expect output without trailing newlines. [[1]](diffhunk://#diff-b4068e86e54a0082d511c2fce87e7894e4f3cf2ae5527c31a609221ac3c93cf6L33-R33) [[2]](diffhunk://#diff-5024599551ca7e1a2a39f38e49ef1dc5315174bcc7ad450e0663edd44e3b7e28L38-R38) [[3]](diffhunk://#diff-5024599551ca7e1a2a39f38e49ef1dc5315174bcc7ad450e0663edd44e3b7e28L57-R57) [[4]](diffhunk://#diff-5024599551ca7e1a2a39f38e49ef1dc5315174bcc7ad450e0663edd44e3b7e28L75-R75) [[5]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L137-R137) [[6]](diffhunk://#diff-bc6e9c48408b5000ea7a696f4a845cc1c227e4311861a63ab040f46fefda3d06L57-R57) [[7]](diffhunk://#diff-bc6e9c48408b5000ea7a696f4a845cc1c227e4311861a63ab040f46fefda3d06L88-R88)

*Runner tests:*
- Updated assertions in `RunnerTest` and `RunnerIOTest` to expect output without trailing newlines. [[1]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL36-R36) [[2]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL60-R60) [[3]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL85-R85) [[4]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL109-R109) [[5]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL156-R156) [[6]](diffhunk://#diff-d101f256674bf4cac78c80915631d95887dc4f83ec8ff96babf54af053222ffcL180-R180) [[7]](diffhunk://#diff-571b7c1c7e31c577585d379fc0167e8b7faa6482f2aa2dd2198eabed0f31bbcbL39-R39) [[8]](diffhunk://#diff-571b7c1c7e31c577585d379fc0167e8b7faa6482f2aa2dd2198eabed0f31bbcbL57-R57)