### PR TITLE
Read fix

### DIFF
--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.9-SNAPSHOT'
+version = '2.0-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Evaluator.kt
@@ -1,6 +1,7 @@
 package org.printscript.interpreter.eval
 
 import org.printscript.interpreter.io.IOContext
+import org.printscript.interpreter.io.OutputProvider
 import org.printscript.interpreter.ir.Binary
 import org.printscript.interpreter.ir.BoolLit
 import org.printscript.interpreter.ir.ExprVisitor
@@ -19,6 +20,7 @@ import org.printscript.interpreter.runtime.asString
 
 internal class Evaluator(
     private val env: Environment,
+    private val output: OutputProvider,
     private val io: IOContext,
 ) : ExprVisitor<Value> {
     override fun visitNum(n: NumLit): Value = Num(n.value)
@@ -31,6 +33,9 @@ internal class Evaluator(
 
     override fun visitReadInput(r: ReadInput): Value {
         val prompt = requireString(r.prompt.accept(this), "readInput")
+        if (prompt.isNotEmpty()) {
+            output.println(prompt)
+        }
         val line = io.input.readLine(prompt) ?: ""
         return Str(line)
     }

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/eval/Executor.kt
@@ -20,7 +20,7 @@ internal class Executor(
     private val output: OutputProvider,
     private val io: IOContext,
 ) : StmtVisitor<Unit> {
-    private val eval = Evaluator(env, io)
+    private val eval = Evaluator(env, output, io)
 
     override fun visitDecl(d: DeclIR) {
         val init = d.initializer?.accept(eval)

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/io/DefaultOutputProvider.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/io/DefaultOutputProvider.kt
@@ -1,5 +1,5 @@
 package org.printscript.interpreter.io
 
 class DefaultOutputProvider : OutputProvider {
-    override fun println(text: String) = kotlin.io.print(text)
+    override fun println(text: String) = kotlin.io.println(text)
 }

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/io/StdinInputProvider.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/io/StdinInputProvider.kt
@@ -6,10 +6,5 @@ import java.io.InputStreamReader
 class StdinInputProvider : InputProvider {
     private val br = BufferedReader(InputStreamReader(System.`in`))
 
-    override fun readLine(prompt: String): String? {
-        if (prompt.isNotBlank()) {
-            println(prompt)
-        }
-        return br.readLine()
-    }
+    override fun readLine(prompt: String): String? = br.readLine()
 }

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/InterpreterHappyPathIT.kt
@@ -106,7 +106,7 @@ class InterpreterHappyPathIT : BaseInterpreterIT() {
         val (interpreter, out) = newInterpreterWithBuffer(ctx)
         interpreter.execute(ast)
 
-        assertEquals(listOf("Ada"), out.lines)
+        assertEquals(listOf("Nombre:", "Ada"), out.lines)
         assertEquals("Ada", interpreter.environmentSnapshot()["name"])
     }
 

--- a/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
+++ b/interpreter/src/test/kotlin/org/printscript/interpreter/eval/EvaluatorTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.printscript.interpreter.io.IOContext
+import org.printscript.interpreter.io.OutputProvider
 import org.printscript.interpreter.ir.AssignIR
 import org.printscript.interpreter.ir.BoolLit
 import org.printscript.interpreter.ir.ConstDeclIR
@@ -28,10 +29,12 @@ import org.printscript.interpreter.util.star
 import org.printscript.interpreter.util.str
 
 class EvaluatorTest {
+    private val silentOutput = OutputProvider { _: String -> }
+
     @Test
     fun `suma y precedencia`() {
         val env = Environment()
-        val ev = Evaluator(env, TestIO.empty)
+        val ev = Evaluator(env, silentOutput, TestIO.empty)
         val expr = plus(num(1.0), star(num(2.0), num(3.0)))
 
         val v = expr.accept(ev)
@@ -40,26 +43,26 @@ class EvaluatorTest {
 
     @Test
     fun `string + string concatena - hola + mundo = holamundo`() {
-        val v = plus(str("hola"), str("mundo")).accept(Evaluator(Environment(), TestIO.empty))
+        val v = plus(str("hola"), str("mundo")).accept(Evaluator(Environment(), silentOutput, TestIO.empty))
         assertEquals(Value.Str("holamundo"), v)
     }
 
     @Test
     fun `string + number concatena - hola + 2025 = hola2025`() {
-        val v = plus(str("hola"), num(2025.0)).accept(Evaluator(Environment(), TestIO.empty))
+        val v = plus(str("hola"), num(2025.0)).accept(Evaluator(Environment(), silentOutput, TestIO.empty))
         assertEquals(Value.Str("hola2025"), v)
     }
 
     @Test
     fun `number + string concatena - 2025 + hola = 2025hola`() {
-        val v = plus(num(2025.0), str("hola")).accept(Evaluator(Environment(), TestIO.empty))
+        val v = plus(num(2025.0), str("hola")).accept(Evaluator(Environment(), silentOutput, TestIO.empty))
         assertEquals(Value.Str("2025hola"), v)
     }
 
     @Test
     fun `plus con booleano lanza error`() {
         val env = Environment()
-        val ev = Evaluator(env, TestIO.empty)
+        val ev = Evaluator(env, silentOutput, TestIO.empty)
         val expr = plus(str("hola"), BoolLit(true))
 
         assertThrows(RuntimeError::class.java) { expr.accept(ev) }
@@ -68,7 +71,7 @@ class EvaluatorTest {
     @Test
     fun `division por cero - lanza RuntimeError`() {
         val env = Environment()
-        val ev = Evaluator(env, TestIO.empty)
+        val ev = Evaluator(env, silentOutput, TestIO.empty)
         val expr = slash(num(1.0), num(0.0))
 
         assertThrows(RuntimeError::class.java) { expr.accept(ev) }
@@ -161,7 +164,7 @@ class EvaluatorTest {
     fun `readInput devuelve el valor del input provider`() {
         val env = Environment()
         val io = IOContext(QueueInputProvider(listOf("Ada")), MapEnvProvider(emptyMap()))
-        val ev = Evaluator(env, io)
+        val ev = Evaluator(env, silentOutput, io)
         val expr = ReadInput(StrLit("Nombre:"))
         val v = expr.accept(ev)
         assertEquals(Value.Str("Ada"), v)
@@ -171,7 +174,7 @@ class EvaluatorTest {
     fun `readEnv devuelve el valor del env provider`() {
         val env = Environment()
         val io = IOContext(QueueInputProvider(emptyList()), MapEnvProvider(mapOf("USER" to "octavia")))
-        val ev = Evaluator(env, io)
+        val ev = Evaluator(env, silentOutput, io)
         val expr = ReadEnv(StrLit("USER"))
         val v = expr.accept(ev)
         assertEquals(Value.Str("octavia"), v)
@@ -181,7 +184,7 @@ class EvaluatorTest {
     fun `readInput sin datos devuelve string vacio`() {
         val env = Environment()
         val io = IOContext(QueueInputProvider(emptyList()), MapEnvProvider(emptyMap()))
-        val ev = Evaluator(env, io)
+        val ev = Evaluator(env, silentOutput, io)
         val expr = ReadInput(StrLit("Prompt"))
         val v = expr.accept(ev)
         assertEquals(Value.Str(""), v)
@@ -191,7 +194,7 @@ class EvaluatorTest {
     fun `readEnv inexistente devuelve string vacio`() {
         val env = Environment()
         val io = IOContext(QueueInputProvider(emptyList()), MapEnvProvider(emptyMap()))
-        val ev = Evaluator(env, io)
+        val ev = Evaluator(env, silentOutput, io)
         val expr = ReadEnv(StrLit("MISSING"))
         val v = expr.accept(ev)
         assertEquals(Value.Str(""), v)

--- a/runner/build.gradle
+++ b/runner/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.4-SNAPSHOT'
+version = '1.5-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/runner/src/test/kotlin/org/printscript/runner/RunnerFileIOTest.kt
+++ b/runner/src/test/kotlin/org/printscript/runner/RunnerFileIOTest.kt
@@ -30,7 +30,7 @@ class RunnerFileIOTest {
                     else -> null
                 }
             }
-        val outputProvider = OutputProvider { text -> outputFile.appendText(text) }
+        val outputProvider = OutputProvider { text -> outputFile.appendText("$text\n") }
         val ioContext = IOContext(inputProvider, envProvider)
         val interpreter = Interpreter(output = outputProvider, ioContext = ioContext)
         val runner =
@@ -45,7 +45,7 @@ class RunnerFileIOTest {
 
         // Verifica el output
         val outputLines = outputFile.readLines()
-        assertEquals(listOf("Ada"), outputLines)
+        assertEquals(listOf("Nombre:", "Ada"), outputLines)
 
         // Limpieza
         inputFile.delete()

--- a/runner/src/test/kotlin/org/printscript/runner/RunnerIOTest.kt
+++ b/runner/src/test/kotlin/org/printscript/runner/RunnerIOTest.kt
@@ -54,6 +54,6 @@ class RunnerIOTest {
         val stream = requireNotNull(javaClass.getResourceAsStream("/programs/v1_1/read-input.ps"))
         stream.use { runner.run(it) }
 
-        assertEquals(listOf("Ada"), output)
+        assertEquals(listOf("Nombre:", "Ada"), output)
     }
 }


### PR DESCRIPTION
This pull request updates the interpreter so that prompts for user input are now printed to the output before reading input, ensuring a better user experience and aligning with expected behavior in both the interpreter and runner. The changes also update tests and output handling to reflect this new behavior.

**Input/Output improvements:**

* The `Evaluator` now prints the prompt (if non-empty) via the `OutputProvider` before reading input, ensuring prompts are visible to users. (`Evaluator.kt`) [[1]](diffhunk://#diff-2c9b762884188f1b8212342a93dcb24e7e286ca6bafef535ae11611821c688f6R23) [[2]](diffhunk://#diff-2c9b762884188f1b8212342a93dcb24e7e286ca6bafef535ae11611821c688f6R36-R38)
* The `Executor` and all test usages of `Evaluator` are updated to pass the required `OutputProvider` parameter. (`Executor.kt`, `EvaluatorTest.kt`) [[1]](diffhunk://#diff-59a9d82ad1f24eeb440090fb127b3b03078c185c895df87e99b683180fac2162L23-R23) Fe3c04ddL29R29, [[2]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L43-R65) [[3]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L71-R74) [[4]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L164-R167) [[5]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L174-R177) [[6]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L184-R187) [[7]](diffhunk://#diff-256c4f82282008e0564cd525b8b9a7906eedaa00e4553938a845a1f4d71df284L194-R197)

**Output consistency:**

* The default output provider now uses `println` instead of `print`, ensuring each output appears on a new line. (`DefaultOutputProvider.kt`)
* The file runner's output provider appends a newline after each output, and related tests are updated to expect prompts in the output. (`RunnerFileIOTest.kt`, `RunnerIOTest.kt`, `InterpreterHappyPathIT.kt`) [[1]](diffhunk://#diff-b08ff8949ffd22bda1105f1f16daae1ffc0781cd7785bd72cdd12d4cf3747418L33-R33) [[2]](diffhunk://#diff-b08ff8949ffd22bda1105f1f16daae1ffc0781cd7785bd72cdd12d4cf3747418L48-R48) [[3]](diffhunk://#diff-571b7c1c7e31c577585d379fc0167e8b7faa6482f2aa2dd2198eabed0f31bbcbL57-R57) [[4]](diffhunk://#diff-b4068e86e54a0082d511c2fce87e7894e4f3cf2ae5527c31a609221ac3c93cf6L109-R109)

**Other updates:**

* Version numbers have been incremented for both the interpreter and runner modules. (`build.gradle`) [[1]](diffhunk://#diff-c4a5399386ce09562085a1d203d679cfe83aa4c5ab884612507e7a4431d76d4cL6-R6) [[2]](diffhunk://#diff-c1f7cbc6f879317726c68411ee40a42a06778b2350757758c319935da82fd413L6-R6)
* The `StdinInputProvider` no longer prints the prompt, as this is now handled by the `Evaluator`. (`StdinInputProvider.kt`)