### PR TITLE
fix: Update version numbers in build.gradle and refactor parser to us…

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.2-SNAPSHOT'
+version = '1.3-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt
@@ -25,23 +25,17 @@ class FrontendAdapter(
     ): Result<List<ASTNode>> {
         val provider = tokenProvider ?: providerFor(languageVersion)
 
-        val tokens =
-            try {
-                val lexer = Lexer(provider)
-                val output = lexer.lex(StringReader(source))
-                println("Lexing: 100%")
-                output
-            } catch (e: LexicalException) {
-                return Result.failure(toCliFailure(e.message ?: "Lexical error", e.line, e.column, sourcePath))
-            } catch (e: Exception) {
-                return Result.failure(toCliFailure(e.message ?: "Lexical error", 1, 1, sourcePath))
-            }
-
         val parser = DefaultParser()
         return try {
-            val ast = parser.parse(tokens)
+            val lexer = Lexer(provider)
+            val tokenStream = lexer.lex(StringReader(source))
+            println("Lexing: 100%")
+
+            val ast = parser.parse(tokenStream).toList()
             println("Parsing: 100%")
             Result.success(ast)
+        } catch (e: LexicalException) {
+            Result.failure(toCliFailure(e.message ?: "Lexical error", e.line, e.column, sourcePath))
         } catch (e: ParseException) {
             Result.failure(toCliFailure(e.message ?: "Parsing error", e.line, e.column, sourcePath))
         } catch (e: Exception) {

--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.4-SNAPSHOT'
+version = '1.5-SNAPSHOT'
 
 repositories { mavenCentral() }
 

--- a/lexer/src/main/kotlin/org/printscript/lexer/Lexer.kt
+++ b/lexer/src/main/kotlin/org/printscript/lexer/Lexer.kt
@@ -7,78 +7,66 @@ import java.io.BufferedReader
 import java.io.Reader
 
 class Lexer(private val tokenProvider: TokenProvider) {
-    fun lexLines(reader: Reader): Iterator<List<Token>> = LineIterator(reader)
+    fun lexLines(reader: Reader): Sequence<List<Token>> =
+        sequence {
+            val bufferedReader: BufferedReader = reader.buffered()
+            var lineNumber = 0
 
-    fun lex(reader: Reader): List<Token> {
-        val flat = mutableListOf<Token>()
-        val it = lexLines(reader)
-        while (it.hasNext()) flat += it.next()
-        val eofPos = if (flat.isEmpty()) 1 else flat.last().column
-        val eofLine = if (flat.isEmpty()) 1 else flat.last().line
-        flat += Token(TokenType.EOF, "", eofLine, eofPos)
-        return flat
-    }
+            while (true) {
+                val rawLine = bufferedReader.readLine() ?: break
+                lineNumber++
+                if (rawLine.isBlank()) continue
 
-    private inner class LineIterator(reader: Reader) : Iterator<List<Token>> {
-        private val bufferedReader: BufferedReader = reader.buffered()
-        private var lineText: String? = null
-        private var lineNumber = 0
-        private var column = 1
-
-        init {
-            nextLine()
+                val tokens = tokenize(rawLine, lineNumber)
+                if (tokens.isNotEmpty()) yield(tokens)
+            }
         }
 
-        private fun nextLine() {
-            lineText = bufferedReader.readLine()
-            lineNumber++
-            column = 1
-        }
-
-        private fun skipBlankLines() {
-            while (lineText != null && lineText!!.isBlank()) nextLine()
-        }
-
-        override fun hasNext(): Boolean {
-            skipBlankLines()
-            return lineText != null
-        }
-
-        override fun next(): List<Token> {
-            if (!hasNext()) throw NoSuchElementException("No more lines to read")
-            val tokens = tokenize(lineText!!)
-            nextLine()
-            return tokens
-        }
-
-        private fun tokenize(line: String): List<Token> {
-            val tokens = mutableListOf<Token>()
-            var pos = 0
-            var col = 1
-
-            fun skipSpace() {
-                while (pos < line.length && line[pos].isWhitespace()) {
-                    pos++
-                    col++
+    fun lex(reader: Reader): Sequence<Token> =
+        sequence {
+            var lastToken: Token? = null
+            for (lineTokens in lexLines(reader)) {
+                for (token in lineTokens) {
+                    lastToken = token
+                    yield(token)
                 }
             }
-
-            while (pos < line.length) {
-                skipSpace()
-                if (pos >= line.length) break
-
-                val match =
-                    tokenProvider.getTokenFor(line, pos)
-                        ?: error("Unexpected character at line $lineNumber, column $col")
-
-                val (lexeme, type) = match
-                val value = lexeme
-                tokens += Token(type, value, lineNumber, col)
-
-                pos += lexeme.length
-                col += lexeme.length
-            }
-            return tokens
+            val eofLine = lastToken?.line ?: 1
+            val eofColumn = lastToken?.column ?: 1
+            yield(Token(TokenType.EOF, "", eofLine, eofColumn))
         }
+
+    fun lexToList(reader: Reader): List<Token> = lex(reader).toList()
+
+    private fun tokenize(
+        line: String,
+        lineNumber: Int,
+    ): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+        var col = 1
+
+        fun skipSpace() {
+            while (pos < line.length && line[pos].isWhitespace()) {
+                pos++
+                col++
+            }
+        }
+
+        while (pos < line.length) {
+            skipSpace()
+            if (pos >= line.length) break
+
+            val match =
+                tokenProvider.getTokenFor(line, pos)
+                    ?: error("Unexpected character at line $lineNumber, column $col")
+
+            val (lexeme, type) = match
+            tokens += Token(type, lexeme, lineNumber, col)
+
+            pos += lexeme.length
+            col += lexeme.length
+        }
+        return tokens
     }
 }

--- a/lexer/src/test/kotlin/org/printscript/lexer/LexerTest.kt
+++ b/lexer/src/test/kotlin/org/printscript/lexer/LexerTest.kt
@@ -18,7 +18,7 @@ class LexerTest {
             """.trimIndent()
 
         val lexer = Lexer(PreConfiguredTokens.TOKENS_1_1)
-        val tokens = lexer.lex(StringReader(code))
+        val tokens = lexer.lex(StringReader(code)).toList()
         val types = tokens.map { it.type }
 
         assertTrue(types.contains(TokenType.LET))
@@ -47,7 +47,7 @@ class LexerTest {
             """.trimIndent()
 
         val lexer = Lexer(PreConfiguredTokens.TOKENS_1_1)
-        val it = lexer.lexLines(StringReader(code))
+        val it = lexer.lexLines(StringReader(code)).iterator()
 
         val l1 = it.next()
         assertEquals(TokenType.LET, l1.first().type)
@@ -63,7 +63,7 @@ class LexerTest {
         val code = "let x: number = $ 10;"
         val lexer = Lexer(PreConfiguredTokens.TOKENS_1_1)
         assertFailsWith<IllegalStateException> {
-            lexer.lex(StringReader(code))
+            lexer.lex(StringReader(code)).toList()
         }
     }
 }

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.4-SNAPSHOT'
+version = '1.5-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/parser/src/main/kotlin/org/printscript/parser/DefaultParser.kt
+++ b/parser/src/main/kotlin/org/printscript/parser/DefaultParser.kt
@@ -1,25 +1,25 @@
 package org.printscript.parser
 
 import org.printscript.parser.helpers.ASTGenerator
-import org.printscript.parser.helpers.TokenHandler
 import org.printscript.parser.node.ASTNode
 import org.printscript.token.Token
 import org.printscript.token.TokenType
 
 class DefaultParser : Parser {
-    override fun parse(list: List<Token>): List<ASTNode> {
-        val handler = TokenHandler(list)
-        val nodes = mutableListOf<ASTNode>()
-        val generator = ASTGenerator()
+    override fun parse(tokens: Sequence<Token>): Sequence<ASTNode> =
+        sequence {
+            val handler = ProgramTokenCursor(tokens)
+            val generator = ASTGenerator()
 
-        while (!handler.isAtEnd() && handler.peek().type != TokenType.EOF) {
-            val statementTokens = collectStatement(handler)
-            nodes += generator.createAST(statementTokens)
+            while (!handler.isAtEnd() && handler.peek().type != TokenType.EOF) {
+                val statementTokens = collectStatement(handler)
+                if (statementTokens.isNotEmpty()) {
+                    yield(generator.createAST(statementTokens))
+                }
+            }
         }
-        return nodes
-    }
 
-    private fun collectStatement(handler: TokenHandler): List<Token> {
+    private fun collectStatement(handler: ProgramTokenCursor): List<Token> {
         val statement = mutableListOf<Token>()
 
         fun take(): Token {
@@ -83,5 +83,37 @@ class DefaultParser : Parser {
             if (t.type == TokenType.SYNTAX && t.value == ";") break
         }
         return statement
+    }
+
+    private class ProgramTokenCursor(tokens: Sequence<Token>) {
+        private val iterator = tokens.iterator()
+        private var lookahead: Token? = null
+        private var exhausted = false
+        private var last: Token = Token(TokenType.EOF, "", 1, 1)
+
+        fun peek(): Token {
+            if (lookahead == null) {
+                lookahead =
+                    if (iterator.hasNext()) {
+                        iterator.next().also { if (it.type == TokenType.EOF) exhausted = true }
+                    } else {
+                        exhausted = true
+                        Token(TokenType.EOF, "", last.line, last.column)
+                    }
+            }
+            return lookahead!!
+        }
+
+        fun advance(): Token {
+            val current = peek()
+            lookahead = null
+            last = current
+            return current
+        }
+
+        fun isAtEnd(): Boolean {
+            val token = peek()
+            return exhausted && token.type == TokenType.EOF
+        }
     }
 }

--- a/parser/src/main/kotlin/org/printscript/parser/Parser.kt
+++ b/parser/src/main/kotlin/org/printscript/parser/Parser.kt
@@ -4,5 +4,7 @@ import org.printscript.parser.node.ASTNode
 import org.printscript.token.Token
 
 interface Parser {
-    fun parse(list: List<Token>): List<ASTNode>
+    fun parse(tokens: Sequence<Token>): Sequence<ASTNode>
+
+    fun parse(list: List<Token>): List<ASTNode> = parse(list.asSequence()).toList()
 }


### PR DESCRIPTION
This pull request refactors the lexer and parser to use Kotlin sequences instead of lists, improving efficiency and streamlining the tokenization and parsing processes. It also updates related interfaces and adapters to support this change, and bumps the project versions for `cli`, `lexer`, and `parser` modules.

**Lexer and Parser API Refactoring:**

* Refactored the `Lexer` class so that `lex` now returns a `Sequence<Token>` instead of a `List<Token>`. Added a `lexToList` helper for list-based usage, and updated the internal logic to use Kotlin sequences for efficient token streaming. (`lexer/src/main/kotlin/org/printscript/lexer/Lexer.kt`)
* Refactored the `DefaultParser` and `Parser` interface so that parsing operates on `Sequence<Token>` and produces a `Sequence<ASTNode>`, with compatibility helpers for lists. Added a `ProgramTokenCursor` to efficiently handle token iteration and lookahead. (`parser/src/main/kotlin/org/printscript/parser/DefaultParser.kt`, `parser/src/main/kotlin/org/printscript/parser/Parser.kt`) [[1]](diffhunk://#diff-d68ac47517c21f694530175a2ea9f914390119bd631a9f8a8dafe28b5b7429daL4-R22) [[2]](diffhunk://#diff-d68ac47517c21f694530175a2ea9f914390119bd631a9f8a8dafe28b5b7429daR87-R118) [[3]](diffhunk://#diff-23881f9947e0c0c9eef47d694a2fd3f886da2e268204e4aeebea12613e24976dL7-R9)

**Adapter and Test Updates:**

* Updated `FrontendAdapter` to use the new sequence-based lexer and parser APIs, and adjusted error handling accordingly. (`cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt`)
* Updated tests in `LexerTest` to work with the new sequence-based API, converting sequences to lists where necessary and adapting iteration logic. (`lexer/src/test/kotlin/org/printscript/lexer/LexerTest.kt`) [[1]](diffhunk://#diff-55973486ef60b149f209fcda6fc5ed9e54c94e33394ff03b96b02ea6d3eb183bL21-R21) [[2]](diffhunk://#diff-55973486ef60b149f209fcda6fc5ed9e54c94e33394ff03b96b02ea6d3eb183bL50-R50) [[3]](diffhunk://#diff-55973486ef60b149f209fcda6fc5ed9e54c94e33394ff03b96b02ea6d3eb183bL66-R66)

**Version Bumps:**

* Bumped the version numbers in `cli`, `lexer`, and `parser` modules to reflect these API changes. (`cli/build.gradle`, `lexer/build.gradle`, `parser/build.gradle`) [[1]](diffhunk://#diff-de8fe44d5ac06e1637fb405beaa31259f0a95163399c0f8cb4158c820b9efcd0L7-R7) [[2]](diffhunk://#diff-a987f7f97a40ffbdc40de50df8d383d102d853765aae36fdbb34c1d1ad45ed77L6-R6) [[3]](diffhunk://#diff-53f6c389782d522fe2b4261a33097ef3edf5fd06b0ae4191a7e603d2642119d7L6-R6)