### PR TITLE
fix: Update version numbers to 2.1-SNAPSHOT and 1.6-SNAPSHOT; refacto…

### DIFF
--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.0-SNAPSHOT'
+version = '2.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
+++ b/interpreter/src/main/kotlin/org/printscript/interpreter/Interpreter.kt
@@ -39,5 +39,21 @@ class Interpreter(
         errorHandler: ErrorHandler? = null,
     ) = execute(ast.asIterable(), errorHandler)
 
+    fun executeNode(
+        node: ASTNode,
+        errorHandler: ErrorHandler? = null,
+    ) {
+        try {
+            val stmt = adapter.toStmt(node)
+            stmt.accept(exec)
+        } catch (oom: OutOfMemoryError) {
+            val handler = errorHandler ?: throw oom
+            handler.reportError(oom.message ?: "Java heap space")
+        } catch (ex: Exception) {
+            val handler = errorHandler ?: throw ex
+            handler.reportError(ex.message ?: ex.toString())
+        }
+    }
+
     fun environmentSnapshot(): Map<String, String> = env.snapshot()
 }

--- a/runner/build.gradle
+++ b/runner/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.6-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/runner/src/main/kotlin/org/printscript/runner/Runner.kt
+++ b/runner/src/main/kotlin/org/printscript/runner/Runner.kt
@@ -17,6 +17,8 @@ class Runner(
         val reader = InputStreamReader(inputStream)
         val tokens = lexer.lex(reader)
         val ast = parser.parse(tokens)
-        interpreter.execute(ast)
+        for (node in ast) {
+            interpreter.executeNode(node)
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new method for executing individual AST nodes in the interpreter and updates the runner to use this method. Additionally, it bumps the version numbers for both the `interpreter` and `runner` modules. The main goal is to provide more granular execution and error handling for each node in the AST.

**Interpreter and Runner Improvements:**

* Added a new `executeNode` method to the `Interpreter` class, allowing execution of a single `ASTNode` with improved error handling.
* Updated the `Runner` class to execute each AST node individually using the new `executeNode` method instead of executing the entire AST at once.

**Version Updates:**

* Bumped `interpreter` module version from `2.0-SNAPSHOT` to `2.1-SNAPSHOT` in `build.gradle`.
* Bumped `runner` module version from `1.5-SNAPSHOT` to `1.6-SNAPSHOT` in `build.gradle`.