### PR TITLE
fix: Update version to 1.6-SNAPSHOT; refactor FrontendAdapter to use …

### DIFF
--- a/cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt
@@ -23,17 +23,11 @@ class FrontendAdapter(
         source: String,
         sourcePath: String,
     ): Result<List<ASTNode>> {
-        val provider = tokenProvider ?: providerFor(languageVersion)
-
-        val parser = DefaultParser()
+        val seqResult = parseProgramSequence(source, sourcePath)
+        if (seqResult.isFailure) return Result.failure(seqResult.exceptionOrNull()!!)
+        val seq = seqResult.getOrThrow()
         return try {
-            val lexer = Lexer(provider)
-            val tokenStream = lexer.lex(StringReader(source))
-            println("Lexing: 100%")
-
-            val ast = parser.parse(tokenStream).toList()
-            println("Parsing: 100%")
-            Result.success(ast)
+            Result.success(seq.toList())
         } catch (e: LexicalException) {
             Result.failure(toCliFailure(e.message ?: "Lexical error", e.line, e.column, sourcePath))
         } catch (e: ParseException) {
@@ -41,6 +35,48 @@ class FrontendAdapter(
         } catch (e: Exception) {
             Result.failure(toCliFailure(e.message ?: "Parsing error", 1, 1, sourcePath))
         }
+    }
+
+    /**
+     * Devuelve Sequence<ASTNode> sin materializar.
+     * Detecta inmediatamente caracteres de control no permitidos y retorna failure.
+     * El resto de errores léxicos/parsing se propagan de forma lazy al consumir la secuencia.
+     */
+    fun parseProgramSequence(
+        source: String,
+        sourcePath: String,
+    ): Result<Sequence<ASTNode>> {
+        // Detección temprana (contrato de test: control chars producen failure inmediato)
+        val badChar = source.firstOrNull { isIllegalControl(it) }
+        if (badChar != null) {
+            return Result.failure(
+                toCliFailure(
+                    "Lexical error: invalid control character 0x${badChar.code.toString(16)}",
+                    1,
+                    1,
+                    sourcePath,
+                ),
+            )
+        }
+        return try {
+            val provider = tokenProvider ?: providerFor(languageVersion)
+            val lexer = Lexer(provider)
+            val tokenStream = lexer.lex(StringReader(source)) // Sequence<Token>
+            val parser = DefaultParser()
+            val astSeq = parser.parse(tokenStream) // Sequence<ASTNode> (lazy)
+            Result.success(astSeq)
+        } catch (e: LexicalException) {
+            // errores léxicos no cubiertos por control-char (si el lexer lanza temprano)
+            Result.failure(toCliFailure(e.message ?: "Lexical error", e.line, e.column, sourcePath))
+        } catch (e: Exception) {
+            Result.failure(toCliFailure(e.message ?: e.toString(), 1, 1, sourcePath))
+        }
+    }
+
+    private fun isIllegalControl(c: Char): Boolean {
+        val code = c.code
+        // Permitimos tab (9), LF (10), CR (13) y cualquier >= 32
+        return code < 32 && code != 9 && code != 10 && code != 13
     }
 
     private fun providerFor(version: String): TokenProvider =

--- a/cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterSequenceTest.kt
+++ b/cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterSequenceTest.kt
@@ -1,0 +1,73 @@
+package org.printscript.cli.adapters
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.printscript.parser.ParseException
+import java.io.File
+
+class FrontendAdapterSequenceTest {
+    @TempDir
+    lateinit var temp: File
+
+    @Test
+    fun `lazy sequence is not evaluated until iterated`() {
+        val source = "let a : string = \"Hi\"; println(a);"
+        val file = temp.resolve("prog.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("1.0")
+        val res = fe.parseProgramSequence(file.readText(), file.path)
+        assertTrue(res.isSuccess, "Result should be success even before consuming the sequence")
+        // Not iterating here: no exception, proves laziness path executed.
+    }
+
+    @Test
+    fun `parse error surfaces during sequence iteration`() {
+        val source = "foo" // invalido: deberia fallar al intentar generar AST
+        val file = temp.resolve("bad.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("1.0")
+        val res = fe.parseProgramSequence(file.readText(), file.path)
+        assertTrue(res.isSuccess, "Creation of sequence succeeds; error deferred to iteration")
+        val seq = res.getOrThrow()
+        assertThrows(ParseException::class.java) { seq.first() }
+    }
+
+    @Test
+    fun `lexical error is captured immediately in sequence result`() {
+        val source = "\u0001" // caracter inválido para el lexer
+        val file = temp.resolve("lex.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("1.0")
+        val res = fe.parseProgramSequence(file.readText(), file.path)
+        assertTrue(res.isFailure, "Lexical error should return failure Result")
+        val failure = res.exceptionOrNull() as CliFailure
+        assertTrue(failure.error.message.contains("Lex") || failure.error.message.contains("lex"))
+    }
+
+    @Test
+    fun `unsupported version surfaces as generic failure`() {
+        val source = "let a : number = 1;"
+        val file = temp.resolve("ver.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("2.0") // versión no soportada
+        val res = fe.parseProgramSequence(file.readText(), file.path)
+        assertTrue(res.isFailure, "Unsupported version should return failure Result")
+        val failure = res.exceptionOrNull() as CliFailure
+        assertTrue(failure.error.message.contains("Unsupported") || failure.error.message.contains("soportada"))
+    }
+
+    @Test
+    fun `valid program sequence yields expected number of nodes`() {
+        val source =
+            """
+            let a : number = 1;
+            let b : number = 2;
+            println(a + b);
+            """.trimIndent()
+        val file = temp.resolve("ok.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("1.0")
+        val res = fe.parseProgramSequence(file.readText(), file.path)
+        val seq = res.getOrThrow()
+        val list = seq.toList()
+        assertEquals(3, list.size, "Expected three top-level statements")
+    }
+}

--- a/cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterVersionTest.kt
+++ b/cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterVersionTest.kt
@@ -1,0 +1,41 @@
+package org.printscript.cli.adapters
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class FrontendAdapterVersionTest {
+    @TempDir
+    lateinit var temp: File
+
+    @Test
+    fun `parseProgram con version 1_1 y if else`() {
+        val source =
+            """
+            let flag : boolean = true;
+            if(flag){
+              println("branchTrue");
+            } else {
+              println("branchFalse");
+            }
+            """.trimIndent()
+        val file = temp.resolve("v11.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("1.1")
+        val res = fe.parseProgram(file.readText(), file.path)
+        assertTrue(res.isSuccess, "Debe parsear correctamente en 1.1")
+        assertTrue(res.getOrThrow().isNotEmpty())
+    }
+
+    @Test
+    fun `parseProgram con version no soportada falla temprano`() {
+        val source = "let x : number = 1;"
+        val file = temp.resolve("badver.ps").apply { writeText(source) }
+        val fe = FrontendAdapter("9.9")
+        val res = fe.parseProgram(file.readText(), file.path)
+        assertTrue(res.isFailure, "Una versión no soportada debe producir failure")
+        val failure = res.exceptionOrNull() as CliFailure
+        assertTrue(failure.error.message.contains("Unsupported") || failure.error.message.contains("soportada"))
+        // Al fallar temprano, no hay AST
+    }
+}

--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.6-SNAPSHOT'
 
 repositories { mavenCentral() }
 

--- a/lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProvider.kt
+++ b/lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProvider.kt
@@ -14,9 +14,7 @@ sealed interface TokenProvider {
 
     companion object {
         infix fun builder(tokenMap: Map<String, TokenType>): TokenProvider {
-            val linked = java.util.LinkedHashMap<String, TokenType>()
-            tokenMap.forEach { (k, v) -> linked[k] = v }
-            return TokenProviderImplementation(linked)
+            return TokenProviderImplementation.from(tokenMap)
         }
     }
 }

--- a/lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProviderImplementation.kt
+++ b/lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProviderImplementation.kt
@@ -2,17 +2,23 @@ package org.printscript.lexer.pattern
 
 import org.printscript.token.TokenType
 
-class TokenProviderImplementation(
-    private val tokens: LinkedHashMap<String, TokenType>,
+private data class TokenPattern(
+    val pattern: String,
+    val regex: Regex,
+    val type: TokenType,
+)
+
+class TokenProviderImplementation private constructor(
+    private val tokens: LinkedHashMap<String, TokenPattern>,
 ) : TokenProvider {
     override fun getTokenFor(
         line: String,
         position: Int,
     ): Pair<String, TokenType>? {
-        for ((pattern, type) in tokens) {
-            val m = Regex(pattern).find(line, position)
+        for (token in tokens.values) {
+            val m = token.regex.find(line, position)
             if (m != null && m.range.first == position) {
-                return m.value to type
+                return m.value to token.type
             }
         }
         return null
@@ -20,9 +26,33 @@ class TokenProviderImplementation(
 
     override fun plus(other: TokenProvider): TokenProvider {
         val merged = LinkedHashMap(tokens)
-        other.iterator().forEach { (k, v) -> merged[k] = v }
-        return TokenProviderImplementation(merged)
+        when (other) {
+            is TokenProviderImplementation -> {
+                other.tokens.values.forEach { token ->
+                    merged[token.pattern] = token
+                }
+            }
+            else -> {
+                other.iterator().forEach { (pattern, type) ->
+                    merged[pattern] = TokenPattern(pattern, Regex(pattern), type)
+                }
+            }
+        }
+        return fromTokens(merged)
     }
 
-    override fun iterator(): Iterator<Pair<String, TokenType>> = tokens.entries.map { it.key to it.value }.iterator()
+    override fun iterator(): Iterator<Pair<String, TokenType>> = tokens.values.map { it.pattern to it.type }.iterator()
+
+    companion object {
+        fun from(tokenMap: Map<String, TokenType>): TokenProviderImplementation {
+            val linked = LinkedHashMap<String, TokenPattern>()
+            tokenMap.forEach { (pattern, type) ->
+                linked[pattern] = TokenPattern(pattern, Regex(pattern), type)
+            }
+            return TokenProviderImplementation(linked)
+        }
+
+        private fun fromTokens(tokens: LinkedHashMap<String, TokenPattern>): TokenProviderImplementation =
+            TokenProviderImplementation(tokens)
+    }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the frontend parsing logic and the token provider infrastructure, with a focus on lazy parsing, early error detection, and better token pattern management. It also adds comprehensive tests to verify the new behaviors and updates the project version.

**Frontend parsing improvements:**

* Refactored `FrontendAdapter` to use a new `parseProgramSequence` method that returns a lazy `Sequence<ASTNode>`, allowing parsing errors to be deferred until the sequence is consumed. This method also performs immediate detection of illegal control characters, returning a failure early if found. (`cli/src/main/kotlin/org/printscript/cli/adapters/FrontendAdapter.kt`) [[1]](diffhunk://#diff-5b54e1121387912f09247ffcbf4480c36b1baa53f262a9ace15756292dada663L26-R30) [[2]](diffhunk://#diff-5b54e1121387912f09247ffcbf4480c36b1baa53f262a9ace15756292dada663R40-R81)

**Token provider and lexer enhancements:**

* Refactored `TokenProviderImplementation` to internally use a `TokenPattern` data class, which precompiles regex patterns for efficiency. Introduced a `from` constructor for easier creation from a token map and improved the `plus` operator to merge token providers more robustly. (`lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProviderImplementation.kt`, `lexer/src/main/kotlin/org/printscript/lexer/pattern/TokenProvider.kt`) [[1]](diffhunk://#diff-f743b16772bbb43fa8dfd186779007a0e904fbd8f24c86d06825d3295c3997e3L5-R57) [[2]](diffhunk://#diff-cb302f35eb0ae9040fb458c3a7d58417d882cb1f2935a5ce8c7053beb1a80944L17-R17)

**Testing and validation:**

* Added `FrontendAdapterSequenceTest` to verify lazy evaluation, error deferral, immediate lexical error detection, version handling, and correct AST node generation for valid programs. (`cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterSequenceTest.kt`)
* Added `FrontendAdapterVersionTest` to confirm correct parsing for supported versions and early failure for unsupported versions. (`cli/src/test/kotlin/org/printscript/cli/adapters/FrontendAdapterVersionTest.kt`)

**Project maintenance:**

* Updated the `lexer` module version from `1.5-SNAPSHOT` to `1.6-SNAPSHOT` to reflect these changes. (`lexer/build.gradle`)