### PR TITLE
fix: Update version to 1.5-SNAPSHOT; add identifier style and read in…

### DIFF
--- a/cli/src/main/kotlin/org/printscript/cli/adapters/LinterAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/LinterAdapter.kt
@@ -3,8 +3,10 @@ package org.printscript.cli.adapters
 import org.printscript.linter.LintConfig
 import org.printscript.linter.Linter
 import org.printscript.linter.issue.Issue
+import org.printscript.linter.rules.IdentifierStyleRule
 import org.printscript.linter.rules.NoDuplicateVariableRule
 import org.printscript.linter.rules.PrintlnRestrictionRule
+import org.printscript.linter.rules.ReadInputPromptRule
 import org.printscript.linter.rules.StringNumberConcatRule
 import org.printscript.parser.node.ASTNode
 
@@ -15,8 +17,10 @@ class LinterAdapter(
             rules =
                 listOf(
                     NoDuplicateVariableRule(),
+                    IdentifierStyleRule(),
                     PrintlnRestrictionRule(),
                     StringNumberConcatRule(),
+                    ReadInputPromptRule(),
                 ),
             config = config,
         ),

--- a/linter/build.gradle
+++ b/linter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.4-SNAPSHOT'
+version = '1.5-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':common')
     implementation project(':lexer')
     implementation project(':token')
+    implementation "com.google.code.gson:gson:2.11.0"
 
     testImplementation(project(":lexer"))
     testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/linter/src/main/kotlin/org/printscript/linter/LintConfig.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/LintConfig.kt
@@ -1,7 +1,18 @@
 package org.printscript.linter
 
+import com.google.gson.Gson
+import java.io.InputStream
+
 enum class IdentifierStyle { CAMEL_CASE, SNAKE_CASE }
 
 data class LintConfig(
     val identifierStyle: IdentifierStyle = IdentifierStyle.CAMEL_CASE,
-)
+) {
+    companion object {
+        private val gson = Gson()
+
+        fun fromJson(json: String): LintConfig = gson.fromJson(json, LintConfig::class.java)
+
+        fun fromInputStream(stream: InputStream): LintConfig = stream.bufferedReader().use { reader -> fromJson(reader.readText()) }
+    }
+}

--- a/linter/src/main/kotlin/org/printscript/linter/Linter.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/Linter.kt
@@ -11,6 +11,7 @@ import org.printscript.parser.node.EmptyExpressionNode
 import org.printscript.parser.node.IfElseNode
 import org.printscript.parser.node.LiteralNode
 import org.printscript.parser.node.PrintStatementNode
+import org.printscript.parser.node.ReadInputNode
 
 class Linter(
     private val rules: List<Rule>,
@@ -38,6 +39,7 @@ class Linter(
                     node.ifBranch.forEach(::visit)
                     node.elseBranch.forEach(::visit)
                 }
+                is ReadInputNode -> visit(node.expression)
                 is LiteralNode<*> -> { }
                 else -> { }
             }

--- a/linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt
@@ -1,0 +1,67 @@
+package org.printscript.linter.rules
+
+import org.printscript.linter.IdentifierStyle
+import org.printscript.linter.issue.Issue
+import org.printscript.linter.issue.Severity
+import org.printscript.linter.util.idRange
+import org.printscript.parser.node.ASTNode
+import org.printscript.parser.node.AssignationNode
+import org.printscript.parser.node.DeclarationNode
+
+class IdentifierStyleRule : Rule {
+    override fun check(
+        node: ASTNode,
+        lintContext: LintContext,
+    ): List<Issue> {
+        val identifier: String
+        val position =
+            when (node) {
+                is DeclarationNode -> {
+                    identifier = node.identifier
+                    node.position
+                }
+                is AssignationNode -> {
+                    identifier = node.variable
+                    node.position
+                }
+                else -> return emptyList()
+            }
+
+        val style = lintContext.config.identifierStyle
+        if (isValid(identifier, style)) return emptyList()
+
+        val range = idRange(identifier, position)
+
+        val expected =
+            when (style) {
+                IdentifierStyle.CAMEL_CASE -> "camelCase"
+                IdentifierStyle.SNAKE_CASE -> "snake_case"
+            }
+
+        return listOf(
+            Issue(
+                ruleId = "identifier-style",
+                message = "Identificador '$identifier' debe respetar el estilo $expected",
+                startLine = range.sl,
+                startCol = range.sc,
+                endLine = range.el,
+                endCol = range.ec,
+                severity = Severity.ERROR,
+            ),
+        )
+    }
+
+    private fun isValid(
+        identifier: String,
+        style: IdentifierStyle,
+    ): Boolean =
+        when (style) {
+            IdentifierStyle.CAMEL_CASE -> CAMEL_CASE.matches(identifier)
+            IdentifierStyle.SNAKE_CASE -> SNAKE_CASE.matches(identifier)
+        }
+
+    companion object {
+        private val CAMEL_CASE = Regex("^[a-z][A-Za-z0-9]*\$")
+        private val SNAKE_CASE = Regex("^[a-z]+(?:_[a-z0-9]+)*\$")
+    }
+}

--- a/linter/src/main/kotlin/org/printscript/linter/rules/ReadInputPromptRule.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/rules/ReadInputPromptRule.kt
@@ -1,0 +1,42 @@
+
+package org.printscript.linter.rules
+
+import org.printscript.linter.issue.Issue
+import org.printscript.linter.issue.Severity
+import org.printscript.linter.util.rangeOf
+import org.printscript.parser.node.ASTNode
+import org.printscript.parser.node.LiteralNode
+import org.printscript.parser.node.ReadInputNode
+import org.printscript.token.TokenType
+
+class ReadInputPromptRule : Rule {
+    override fun check(
+        node: ASTNode,
+        lintContext: LintContext,
+    ): List<Issue> {
+        if (node !is ReadInputNode) return emptyList()
+
+        val prompt = node.expression
+        val isValid =
+            when (prompt) {
+                is LiteralNode<*> ->
+                    prompt.tokenType == TokenType.STRING || prompt.tokenType == TokenType.IDENTIFIER
+                else -> false
+            }
+
+        if (isValid) return emptyList()
+
+        val range = rangeOf(node)
+        return listOf(
+            Issue(
+                ruleId = "read-input-prompt",
+                message = "readInput solo admite literales de cadena o identificadores como prompt",
+                startLine = range.sl,
+                startCol = range.sc,
+                endLine = range.el,
+                endCol = range.ec,
+                severity = Severity.ERROR,
+            ),
+        )
+    }
+}

--- a/linter/src/main/kotlin/org/printscript/linter/util/Range.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/util/Range.kt
@@ -7,6 +7,7 @@ import org.printscript.parser.node.DeclarationNode
 import org.printscript.parser.node.DoubleExpressionNode
 import org.printscript.parser.node.LiteralNode
 import org.printscript.parser.node.PrintStatementNode
+import org.printscript.parser.node.ReadInputNode
 
 data class Range(val sl: Int, val sc: Int, val el: Int, val ec: Int)
 
@@ -19,6 +20,7 @@ fun rangeOf(node: ASTNode): Range =
         is PrintStatementNode -> p(node.position)
         is DoubleExpressionNode -> p(node.position)
         is LiteralNode<*> -> Range(1, 1, 1, 1)
+        is ReadInputNode -> p(node.position)
         else -> Range(1, 1, 1, 1)
     }
 

--- a/linter/src/main/kotlin/org/printscript/linter/util/TypeInfer.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/util/TypeInfer.kt
@@ -5,6 +5,7 @@ import org.printscript.parser.node.ASTNode
 import org.printscript.parser.node.AssignationNode
 import org.printscript.parser.node.DoubleExpressionNode
 import org.printscript.parser.node.LiteralNode
+import org.printscript.parser.node.ReadInputNode
 
 fun inferType(
     expr: ASTNode,
@@ -39,6 +40,7 @@ fun inferType(
             }
 
         is AssignationNode -> inferType(expr.expression, lintContext)
+        is ReadInputNode -> "string"
 
         else -> null
     }

--- a/linter/src/test/kotlin/org/printscript/linter/RulesTest.kt
+++ b/linter/src/test/kotlin/org/printscript/linter/RulesTest.kt
@@ -4,15 +4,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.printscript.linter.issue.Severity
+import org.printscript.linter.rules.IdentifierStyleRule
 import org.printscript.linter.rules.LintContext
 import org.printscript.linter.rules.NoDuplicateVariableRule
 import org.printscript.linter.rules.PrintlnRestrictionRule
+import org.printscript.linter.rules.ReadInputPromptRule
 import org.printscript.linter.rules.StringNumberConcatRule
 import org.printscript.linter.testutil.TestUtils.declConst
 import org.printscript.linter.testutil.TestUtils.declVar
+import org.printscript.linter.testutil.TestUtils.identifier
 import org.printscript.linter.testutil.TestUtils.num
 import org.printscript.linter.testutil.TestUtils.plus
 import org.printscript.linter.testutil.TestUtils.printlnNode
+import org.printscript.linter.testutil.TestUtils.readInput
 import org.printscript.linter.testutil.TestUtils.str
 
 class RulesTest {
@@ -70,5 +74,42 @@ class RulesTest {
         assertEquals("string-number-concat", i2.first().ruleId)
         assertTrue(i3.isEmpty())
         assertTrue(i4.isEmpty())
+    }
+
+    @Test
+    fun `IdentifierStyleRule honours config`() {
+        val camelRule = IdentifierStyleRule()
+        val camelCtx = LintContext(LintConfig(identifierStyle = IdentifierStyle.CAMEL_CASE))
+        val snakeRule = IdentifierStyleRule()
+        val snakeCtx = LintContext(LintConfig(identifierStyle = IdentifierStyle.SNAKE_CASE))
+
+        val camelOk = declVar("validName", "string", str("ok"), 1, 1)
+        val camelBad = declVar("invalid_name", "string", str("ok"), 2, 1)
+        val snakeOk = declVar("valid_name", "string", str("ok"), 3, 1)
+        val snakeBad = declVar("invalidName", "string", str("ok"), 4, 1)
+
+        assertTrue(camelRule.check(camelOk, camelCtx).isEmpty())
+        assertEquals(1, camelRule.check(camelBad, camelCtx).size)
+
+        assertTrue(snakeRule.check(snakeOk, snakeCtx).isEmpty())
+        assertEquals(1, snakeRule.check(snakeBad, snakeCtx).size)
+    }
+
+    @Test
+    fun `ReadInputPromptRule forbids complex expressions`() {
+        val rule = ReadInputPromptRule()
+        val ctx = LintContext(LintConfig())
+
+        val literalPrompt = readInput(str("nombre"))
+        val identifierPrompt = readInput(identifier("prompt"))
+        val invalidPrompt = readInput(plus(str("a"), str("b")))
+
+        assertTrue(rule.check(literalPrompt, ctx).isEmpty())
+        assertTrue(rule.check(identifierPrompt, ctx).isEmpty())
+
+        val issues = rule.check(invalidPrompt, ctx)
+        assertEquals(1, issues.size)
+        assertEquals("read-input-prompt", issues.first().ruleId)
+        assertEquals(Severity.ERROR, issues.first().severity)
     }
 }

--- a/linter/src/test/kotlin/org/printscript/linter/testutil/TestUtils.kt
+++ b/linter/src/test/kotlin/org/printscript/linter/testutil/TestUtils.kt
@@ -9,6 +9,7 @@ import org.printscript.parser.node.DoubleExpressionNode
 import org.printscript.parser.node.IfElseNode
 import org.printscript.parser.node.LiteralNode
 import org.printscript.parser.node.PrintStatementNode
+import org.printscript.parser.node.ReadInputNode
 import org.printscript.parser.node.VariableDeclarationNode
 import org.printscript.token.TokenType
 
@@ -21,6 +22,8 @@ object TestUtils {
     fun num(n: Number) = LiteralNode(n, TokenType.NUMBER)
 
     fun str(s: String) = LiteralNode(s, TokenType.STRING)
+
+    fun identifier(name: String) = LiteralNode(name, TokenType.IDENTIFIER)
 
     fun bool(b: Boolean) = LiteralNode(b, if (b) TokenType.TRUE else TokenType.FALSE)
 
@@ -57,6 +60,12 @@ object TestUtils {
         line: Int = 1,
         col: Int = 1,
     ) = PrintStatementNode(expr, pos(line, col))
+
+    fun readInput(
+        expr: ASTNode,
+        line: Int = 1,
+        col: Int = 1,
+    ) = ReadInputNode(expr, pos(line, col))
 
     fun declVar(
         name: String,


### PR DESCRIPTION
This pull request introduces two new linter rules to the PrintScript linter, improves configuration handling, and enhances test coverage and utility functions. The most significant changes are the addition of the `IdentifierStyleRule` and `ReadInputPromptRule`, which enforce identifier naming conventions and restrict the prompt expression in `readInput` statements, respectively. The configuration system is now JSON-compatible, and related tests and utilities have been updated accordingly.

**New Linter Rules:**

* Added `IdentifierStyleRule` to enforce identifier naming style (camelCase or snake_case) based on configuration. [[1]](diffhunk://#diff-56688350e8f58474af5a4bd3f3d400cf4c05e34cb6c6339129a9687ccd2cbaefR1-R67) [[2]](diffhunk://#diff-9004994edb0f0d51477f371a5b61fe032633b9780e20682d6ddf19f238ada699R6-R9) [[3]](diffhunk://#diff-9004994edb0f0d51477f371a5b61fe032633b9780e20682d6ddf19f238ada699R20-R23)
* Added `ReadInputPromptRule` to ensure `readInput` only accepts string literals or identifiers as prompt expressions. [[1]](diffhunk://#diff-f818845a4bed6a109547abe8b9708466d26c04317f04bcf84e45633bfaa3194dR1-R42) [[2]](diffhunk://#diff-9004994edb0f0d51477f371a5b61fe032633b9780e20682d6ddf19f238ada699R6-R9) [[3]](diffhunk://#diff-9004994edb0f0d51477f371a5b61fe032633b9780e20682d6ddf19f238ada699R20-R23)

**Configuration and Dependency Updates:**

* Enhanced `LintConfig` to support JSON deserialization and loading from input streams, and updated the linter module version to 1.5-SNAPSHOT. [[1]](diffhunk://#diff-fb748009cb65d3a0c5f999509eb716a996abf14eb36f55c048cf30b68f2cbd0fR3-R18) [[2]](diffhunk://#diff-8f5ee92674fa0501f08ebe4f36e7e5103580e399afe9b58928e39d4a34cbfd56L6-R6)
* Added Gson as a dependency for JSON handling in the linter module.

**Parser and Type Inference Support:**

* Updated the linter and utility functions to recognize and process `ReadInputNode` in AST traversal, range calculation, and type inference. [[1]](diffhunk://#diff-3c7f9b45b79e59a77b0211e9b47da865ded1d2510f4949b1569a7cc6a2b621f0R14) [[2]](diffhunk://#diff-3c7f9b45b79e59a77b0211e9b47da865ded1d2510f4949b1569a7cc6a2b621f0R42) [[3]](diffhunk://#diff-79a185f6d000c093b437453bfcd8e3c3bbe718556401b3f89e7820c504218797R10) [[4]](diffhunk://#diff-79a185f6d000c093b437453bfcd8e3c3bbe718556401b3f89e7820c504218797R23) [[5]](diffhunk://#diff-3215cfa74281a7194d0b3844b6515f7ec2322f58bfbbfc21de96413913384a2aR8) [[6]](diffhunk://#diff-3215cfa74281a7194d0b3844b6515f7ec2322f58bfbbfc21de96413913384a2aR43)

**Testing Enhancements:**

* Added comprehensive tests for both new rules in `RulesTest`, verifying correct enforcement and error reporting. [[1]](diffhunk://#diff-3da1151d636ec93421416aec66f4ec8076548e67ffea90ed14a2ba2756082220R7-R19) [[2]](diffhunk://#diff-3da1151d636ec93421416aec66f4ec8076548e67ffea90ed14a2ba2756082220R78-R114)
* Extended test utilities to easily create identifier and readInput AST nodes for testing purposes. [[1]](diffhunk://#diff-9cf8730dd672127e69da6558434bd1db6294d4bc8ab216b3f74180765abf57dbR12) [[2]](diffhunk://#diff-9cf8730dd672127e69da6558434bd1db6294d4bc8ab216b3f74180765abf57dbR26-R27) [[3]](diffhunk://#diff-9cf8730dd672127e69da6558434bd1db6294d4bc8ab216b3f74180765abf57dbR64-R69)