### PR TITLE
Linter fix

### DIFF
--- a/linter/build.gradle
+++ b/linter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.6-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/linter/src/main/kotlin/org/printscript/linter/LintConfig.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/LintConfig.kt
@@ -1,18 +1,7 @@
 package org.printscript.linter
 
-import com.google.gson.Gson
-import java.io.InputStream
-
 enum class IdentifierStyle { CAMEL_CASE, SNAKE_CASE }
 
 data class LintConfig(
-    val identifierStyle: IdentifierStyle = IdentifierStyle.CAMEL_CASE,
-) {
-    companion object {
-        private val gson = Gson()
-
-        fun fromJson(json: String): LintConfig = gson.fromJson(json, LintConfig::class.java)
-
-        fun fromInputStream(stream: InputStream): LintConfig = stream.bufferedReader().use { reader -> fromJson(reader.readText()) }
-    }
-}
+    val identifierStyle: IdentifierStyle? = null,
+)

--- a/linter/src/main/kotlin/org/printscript/linter/LintConfigLoader.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/LintConfigLoader.kt
@@ -1,0 +1,30 @@
+package org.printscript.linter
+
+import com.google.gson.JsonParser
+import java.io.InputStream
+import java.io.InputStreamReader
+
+object LintConfigLoader {
+    fun load(stream: InputStream?): LintConfig {
+        if (stream == null) return LintConfig()
+        return try {
+            val el = JsonParser.parseReader(InputStreamReader(stream))
+            if (!el.isJsonObject) return LintConfig()
+            val obj = el.asJsonObject
+            val style = parseIdentifierStyle(obj.get("identifier_format")?.asString)
+            LintConfig(identifierStyle = style)
+        } catch (_: Exception) {
+            LintConfig()
+        }
+    }
+
+    private fun parseIdentifierStyle(raw: String?): IdentifierStyle? {
+        if (raw == null) return null
+        val norm = raw.lowercase().replace(Regex("[ _-]"), "")
+        return when (norm) {
+            "camelcase" -> IdentifierStyle.CAMEL_CASE
+            "snakecase" -> IdentifierStyle.SNAKE_CASE
+            else -> null
+        }
+    }
+}

--- a/linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt
+++ b/linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt
@@ -13,25 +13,18 @@ class IdentifierStyleRule : Rule {
         node: ASTNode,
         lintContext: LintContext,
     ): List<Issue> {
-        val identifier: String
-        val position =
+        val style = lintContext.config.identifierStyle ?: return emptyList() // sin estilo -> no aplica
+
+        val (identifier, position) =
             when (node) {
-                is DeclarationNode -> {
-                    identifier = node.identifier
-                    node.position
-                }
-                is AssignationNode -> {
-                    identifier = node.variable
-                    node.position
-                }
+                is DeclarationNode -> node.identifier to node.position
+                is AssignationNode -> node.variable to node.position
                 else -> return emptyList()
             }
 
-        val style = lintContext.config.identifierStyle
         if (isValid(identifier, style)) return emptyList()
 
         val range = idRange(identifier, position)
-
         val expected =
             when (style) {
                 IdentifierStyle.CAMEL_CASE -> "camelCase"
@@ -52,16 +45,16 @@ class IdentifierStyleRule : Rule {
     }
 
     private fun isValid(
-        identifier: String,
+        name: String,
         style: IdentifierStyle,
     ): Boolean =
         when (style) {
-            IdentifierStyle.CAMEL_CASE -> CAMEL_CASE.matches(identifier)
-            IdentifierStyle.SNAKE_CASE -> SNAKE_CASE.matches(identifier)
+            IdentifierStyle.CAMEL_CASE -> CAMEL_REGEX.matches(name)
+            IdentifierStyle.SNAKE_CASE -> SNAKE_REGEX.matches(name)
         }
 
     companion object {
-        private val CAMEL_CASE = Regex("^[a-z][A-Za-z0-9]*\$")
-        private val SNAKE_CASE = Regex("^[a-z]+(?:_[a-z0-9]+)*\$")
+        private val CAMEL_REGEX = Regex("^[a-z]+(?:[A-Z][a-z0-9]*)*$")
+        private val SNAKE_REGEX = Regex("^[a-z]+(?:_[a-z0-9]+)*$")
     }
 }


### PR DESCRIPTION
This pull request refactors how linter configuration is loaded and handled, especially regarding identifier style rules. It introduces a dedicated loader for configuration, updates how identifier styles are parsed and validated, and improves robustness when no style is specified. The changes also update the project version.

**Linter configuration and loading improvements:**

* Added a new `LintConfigLoader` singleton to handle loading and parsing linter configuration from an input stream, including robust handling of missing or malformed config and normalization of identifier style strings. (`linter/src/main/kotlin/org/printscript/linter/LintConfigLoader.kt`)
* Refactored `LintConfig` to remove direct JSON parsing methods and make `identifierStyle` nullable, delegating config loading responsibilities to the new loader. (`linter/src/main/kotlin/org/printscript/linter/LintConfig.kt`)

**Identifier style rule enhancements:**

* Updated `IdentifierStyleRule` to skip checks if no style is configured, and streamlined extraction of identifier and position from AST nodes. (`linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt`)
* Improved identifier validation logic and regexes, making camelCase and snake_case detection more accurate and consistent with common conventions. (`linter/src/main/kotlin/org/printscript/linter/rules/IdentifierStyleRule.kt`)

**Version update:**

* Bumped the linter project version from `1.5-SNAPSHOT` to `1.6-SNAPSHOT` in `build.gradle`. (`linter/build.gradle`)