### PR TITLE
feat: Enhance ASTEmitter with support for if-else statements and add …

### DIFF
--- a/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
@@ -1,6 +1,7 @@
 package org.printscript.cli.adapters
 
 import org.printscript.formatter.CodeFormatter
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.ConfigJsonReader
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.parser.node.ASTNode
@@ -10,7 +11,7 @@ class FormatterAdapter {
 
     fun loadConfig(path: String?): FormatterConfig =
         if (path.isNullOrBlank()) {
-            FormatterConfig()
+            FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
         } else {
             ConfigJsonReader().readFromFile(path)
         }

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.6-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
@@ -1,11 +1,120 @@
 package org.printscript.formatter.config
 
-import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
 import java.io.File
 
 class ConfigJsonReader {
     fun readFromFile(path: String): FormatterConfig {
         val json = File(path).readText()
-        return Gson().fromJson(json, FormatterConfig::class.java)
+        if (json.isBlank()) {
+            return FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
+        }
+
+        val element = JsonParser.parseString(json)
+        if (!element.isJsonObject) {
+            return FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
+        }
+
+        val obj = element.asJsonObject
+        val defaults = FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
+
+        return FormatterConfig(
+            spaceBeforeColon = obj.optBoolean("spaceBeforeColon") ?: defaults.spaceBeforeColon,
+            spaceAfterColon = obj.optBoolean("spaceAfterColon") ?: defaults.spaceAfterColon,
+            spaceAroundEquals = obj.optBoolean("spaceAroundEquals") ?: defaults.spaceAroundEquals,
+            spaceAroundOperators = obj.optBoolean("spaceAroundOperators") ?: defaults.spaceAroundOperators,
+            lineJumpBeforePrintln = obj.optInt("lineJumpBeforePrintln") ?: defaults.lineJumpBeforePrintln,
+            lineJumpAfterSemicolon =
+                obj.optBoolean("lineJumpAfterSemicolon") ?: defaults.lineJumpAfterSemicolon,
+            indentSize = obj.optInt("indentSize") ?: defaults.indentSize,
+            braceStyle = obj.optBraceStyle() ?: defaults.braceStyle,
+        )
     }
 }
+
+private fun JsonObject.optBoolean(vararg keys: String): Boolean? {
+    for (key in keys) {
+        if (!has(key)) continue
+        val primitive = get(key)?.asPrimitiveOrNull() ?: continue
+        val bool = primitive.asFlexibleBoolean()
+        if (bool != null) {
+            return bool
+        }
+    }
+    return null
+}
+
+private fun JsonObject.optInt(vararg keys: String): Int? {
+    for (key in keys) {
+        if (!has(key)) continue
+        val primitive = get(key)?.asPrimitiveOrNull() ?: continue
+        if (primitive.isNumber) {
+            return primitive.asInt
+        }
+        if (primitive.isString) {
+            primitive.asString.trim().toIntOrNull()?.let { return it }
+        }
+    }
+    return null
+}
+
+private fun JsonObject.optBraceStyle(): BraceStyle? {
+    val keys =
+        listOf(
+            "braceStyle",
+            "bracePosition",
+            "ifBraceStyle",
+            "ifBracePosition",
+            "ifBraceSameLine",
+            "braceSameLine",
+            "braceOnSameLine",
+            "braceOnNewLine",
+            "braceBelowStatement",
+            "braceBelow",
+            "braceNextLine",
+        )
+
+    for (key in keys) {
+        if (!has(key)) continue
+        val primitive = get(key)?.asPrimitiveOrNull() ?: continue
+        val keyLower = key.lowercase()
+
+        val bool = primitive.asFlexibleBoolean()
+        if (bool != null) {
+            return when {
+                keyLower.contains("newline") || keyLower.contains("below") || keyLower.contains("nextline") ->
+                    if (bool) BraceStyle.NEXT_LINE else BraceStyle.SAME_LINE
+                keyLower.contains("sameline") -> if (bool) BraceStyle.SAME_LINE else BraceStyle.NEXT_LINE
+                else -> if (bool) BraceStyle.SAME_LINE else BraceStyle.NEXT_LINE
+            }
+        }
+
+        if (primitive.isString) {
+            val normalized = primitive.asString.lowercase().replace("[^a-z]".toRegex(), "")
+            return when (normalized) {
+                "sameline", "inline", "same" -> BraceStyle.SAME_LINE
+                "nextline", "newline", "below", "under", "next" -> BraceStyle.NEXT_LINE
+                else -> null
+            }
+        }
+    }
+    return null
+}
+
+private fun JsonPrimitive.asFlexibleBoolean(): Boolean? =
+    when {
+        isBoolean -> asBoolean
+        isNumber -> asInt != 0
+        isString ->
+            when (asString.trim().lowercase()) {
+                "true", "1", "yes", "y", "on" -> true
+                "false", "0", "no", "n", "off" -> false
+                else -> null
+            }
+        else -> null
+    }
+
+private fun JsonElement?.asPrimitiveOrNull(): JsonPrimitive? = if (this is JsonPrimitive) this else null

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
@@ -1,5 +1,10 @@
 package org.printscript.formatter.config
 
+enum class BraceStyle {
+    SAME_LINE,
+    NEXT_LINE,
+}
+
 data class FormatterConfig(
     val spaceBeforeColon: Boolean = false,
     val spaceAfterColon: Boolean = true,
@@ -8,4 +13,5 @@ data class FormatterConfig(
     val lineJumpBeforePrintln: Int = 0,
     val lineJumpAfterSemicolon: Boolean = true,
     val indentSize: Int = 4,
+    val braceStyle: BraceStyle = BraceStyle.SAME_LINE,
 )

--- a/formatter/src/main/kotlin/org/printscript/formatter/emit/ASTEmitter.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/emit/ASTEmitter.kt
@@ -1,112 +1,239 @@
 package org.printscript.formatter.emit
 
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.formatter.rules.FormatToken
-import org.printscript.formatter.rules.FormatToken.CloseParen
-import org.printscript.formatter.rules.FormatToken.Colon
-import org.printscript.formatter.rules.FormatToken.Equals
-import org.printscript.formatter.rules.FormatToken.Ident
-import org.printscript.formatter.rules.FormatToken.Keyword
-import org.printscript.formatter.rules.FormatToken.NewLine
-import org.printscript.formatter.rules.FormatToken.NumberLit
-import org.printscript.formatter.rules.FormatToken.Op
-import org.printscript.formatter.rules.FormatToken.OpKind
-import org.printscript.formatter.rules.FormatToken.OpenParen
-import org.printscript.formatter.rules.FormatToken.Semicolon
-import org.printscript.formatter.rules.FormatToken.StringLit
-import org.printscript.formatter.rules.FormatToken.TypeName
 import org.printscript.parser.node.ASTNode
 import org.printscript.parser.node.AssignationNode
 import org.printscript.parser.node.DeclarationNode
 import org.printscript.parser.node.DoubleExpressionNode
 import org.printscript.parser.node.EmptyExpressionNode
+import org.printscript.parser.node.IfElseNode
 import org.printscript.parser.node.LiteralNode
 import org.printscript.parser.node.PrintStatementNode
+import org.printscript.parser.node.ReadEnvNode
+import org.printscript.parser.node.ReadInputNode
+import org.printscript.token.TokenType
 
 class ASTEmitter(private val cfg: FormatterConfig) {
     fun emitProgram(program: List<ASTNode>): List<FormatToken> {
-        val out = mutableListOf<FormatToken>()
-        program.forEach { emitStmt(it, out) }
-        return out
+        val acc = TokenAccumulator()
+        emitStatements(program, acc)
+        return acc.tokens
+    }
+
+    private fun emitStatements(
+        statements: List<ASTNode>,
+        acc: TokenAccumulator,
+    ) {
+        statements.forEachIndexed { index, stmt ->
+            emitStmt(stmt, acc, index == statements.lastIndex)
+        }
     }
 
     private fun emitStmt(
-        n: ASTNode,
-        sink: MutableList<FormatToken>,
+        node: ASTNode,
+        acc: TokenAccumulator,
+        isLastInBlock: Boolean,
     ) {
-        when (n) {
-            is DeclarationNode -> {
-                sink += Keyword("let")
-                sink += Ident(n.identifier)
-                sink += Colon
-                sink += TypeName(n.valueType)
-                if (n.expression !== EmptyExpressionNode) {
-                    sink += Equals
-                    emitExpr(n.expression, sink)
-                }
-                sink += Semicolon
+        when (node) {
+            is DeclarationNode -> emitDeclaration(node, acc)
+            is AssignationNode -> emitAssignation(node, acc)
+            is PrintStatementNode -> emitPrint(node, acc)
+            is IfElseNode -> emitIfElse(node, acc, isLastInBlock)
+            else -> error("Sentencia no soportada por el formatter: ${node::class.simpleName}")
+        }
+    }
+
+    private fun emitDeclaration(
+        node: DeclarationNode,
+        acc: TokenAccumulator,
+    ) {
+        acc.addKeyword("let")
+        acc.add(FormatToken.Ident(node.identifier))
+        acc.add(FormatToken.Colon)
+        acc.add(FormatToken.TypeName(node.valueType))
+        if (node.expression !== EmptyExpressionNode) {
+            acc.add(FormatToken.Equals)
+            emitExpr(node.expression, acc)
+        }
+        acc.add(FormatToken.Semicolon)
+    }
+
+    private fun emitAssignation(
+        node: AssignationNode,
+        acc: TokenAccumulator,
+    ) {
+        acc.add(FormatToken.Ident(node.variable))
+        acc.add(FormatToken.Equals)
+        emitExpr(node.expression, acc)
+        acc.add(FormatToken.Semicolon)
+    }
+
+    private fun emitPrint(
+        node: PrintStatementNode,
+        acc: TokenAccumulator,
+    ) {
+        acc.newline(cfg.lineJumpBeforePrintln)
+        acc.addKeyword("println")
+        acc.add(FormatToken.OpenParen)
+        emitExpr(node.expression, acc)
+        acc.add(FormatToken.CloseParen)
+        acc.add(FormatToken.Semicolon)
+    }
+
+    private fun emitIfElse(
+        node: IfElseNode,
+        acc: TokenAccumulator,
+        isLastInBlock: Boolean,
+    ) {
+        acc.addKeyword("if")
+        acc.addSpace()
+        acc.add(FormatToken.OpenParen)
+        emitExpr(node.condition, acc)
+        acc.add(FormatToken.CloseParen)
+
+        appendOpenBrace(acc)
+        acc.withIndent { emitStatements(node.ifBranch, acc) }
+        ensureBlockClosingLine(node.ifBranch, acc)
+        acc.add(FormatToken.CloseBrace)
+
+        if (node.elseBranch.isNotEmpty()) {
+            if (cfg.braceStyle == BraceStyle.SAME_LINE) {
+                acc.addSpace()
+                acc.addKeyword("else")
+            } else {
+                acc.newline()
+                acc.addKeyword("else")
+            }
+            appendOpenBrace(acc)
+            acc.withIndent { emitStatements(node.elseBranch, acc) }
+            ensureBlockClosingLine(node.elseBranch, acc)
+            acc.add(FormatToken.CloseBrace)
+        }
+
+        if (!isLastInBlock) {
+            acc.newline()
+        } else {
+            acc.markLineStart()
+        }
+    }
+
+    private fun appendOpenBrace(acc: TokenAccumulator) {
+        when (cfg.braceStyle) {
+            BraceStyle.SAME_LINE -> {
+                acc.addSpace()
+                acc.add(FormatToken.OpenBrace)
+                acc.newline()
             }
 
-            is AssignationNode -> {
-                sink += Ident(n.variable)
-                sink += Equals
-                emitExpr(n.expression, sink)
-                sink += Semicolon
+            BraceStyle.NEXT_LINE -> {
+                acc.newline()
+                acc.add(FormatToken.OpenBrace)
+                acc.newline()
             }
+        }
+    }
 
-            is PrintStatementNode -> {
-                repeat(cfg.lineJumpBeforePrintln) { sink += NewLine() }
-                sink += Keyword("println")
-                sink += OpenParen
-                emitExpr(n.expression, sink)
-                sink += CloseParen
-                sink += Semicolon
-            }
+    private fun ensureBlockClosingLine(
+        statements: List<ASTNode>,
+        acc: TokenAccumulator,
+    ) {
+        if (acc.isAtLineStart()) {
+            return
+        }
 
-            else -> error("Sentencia no soportada por el formatter: ${n::class.simpleName}")
+        if (statements.isEmpty()) {
+            acc.markLineStart()
+            return
+        }
+
+        if (!cfg.lineJumpAfterSemicolon || statements.last() is IfElseNode) {
+            acc.newline()
         }
     }
 
     private fun emitExpr(
-        n: ASTNode,
-        sink: MutableList<FormatToken>,
+        node: ASTNode,
+        acc: TokenAccumulator,
     ) {
-        when (n) {
+        when (node) {
             is DoubleExpressionNode -> {
-                emitExpr(n.left, sink)
-                sink +=
-                    Op(
-                        when (n.operator.trim()) {
-                            "+" -> OpKind.PLUS
-                            "-" -> OpKind.MINUS
-                            "*" -> OpKind.STAR
-                            "/" -> OpKind.SLASH
-                            else -> error("Operador no soportado: '${n.operator}'")
+                emitExpr(node.left, acc)
+                acc.add(
+                    FormatToken.Op(
+                        when (node.operator.trim()) {
+                            "+" -> FormatToken.OpKind.PLUS
+                            "-" -> FormatToken.OpKind.MINUS
+                            "*" -> FormatToken.OpKind.STAR
+                            "/" -> FormatToken.OpKind.SLASH
+                            else -> error("Operador no soportado: '${node.operator}'")
                         },
-                    )
-                emitExpr(n.right, sink)
+                    ),
+                )
+                emitExpr(node.right, acc)
             }
 
-            is LiteralNode<*> -> emitLiteral(n, sink)
-
-            else -> error("Expresión no soportada por el formatter: ${n::class.simpleName}")
+            is LiteralNode<*> -> emitLiteral(node, acc)
+            is ReadInputNode -> emitReadCall("readInput", node.expression, acc)
+            is ReadEnvNode -> emitReadCall("readEnv", node.expression, acc)
+            else -> error("Expresión no soportada por el formatter: ${node::class.simpleName}")
         }
     }
 
-    private fun emitLiteral(
-        n: LiteralNode<*>,
-        sink: MutableList<FormatToken>,
+    private fun emitReadCall(
+        name: String,
+        argument: ASTNode,
+        acc: TokenAccumulator,
     ) {
-        when (val v = n.value) {
-            is Number -> sink += NumberLit(v.toString())
+        acc.addKeyword(name)
+        acc.add(FormatToken.OpenParen)
+        emitExpr(argument, acc)
+        acc.add(FormatToken.CloseParen)
+    }
+
+    private fun emitLiteral(
+        node: LiteralNode<*>,
+        acc: TokenAccumulator,
+    ) {
+        val tokenType = node.tokenType
+        when (tokenType) {
+            TokenType.IDENTIFIER -> {
+                acc.add(FormatToken.Ident(node.value.toString()))
+                return
+            }
+
+            TokenType.TRUE, TokenType.FALSE -> {
+                acc.add(FormatToken.Ident(node.value.toString()))
+                return
+            }
+
+            TokenType.NUMBER -> {
+                acc.add(FormatToken.NumberLit(node.value.toString()))
+                return
+            }
+
+            TokenType.STRING -> {
+                val normalized = unquoteAndUnescape(node.value.toString())
+                acc.add(FormatToken.StringLit(normalized))
+                return
+            }
+
+            else -> {}
+        }
+
+        when (val value = node.value) {
+            is Number -> acc.add(FormatToken.NumberLit(value.toString()))
+            is Boolean -> acc.add(FormatToken.Ident(value.toString()))
             is String -> {
-                val normalized = unquoteAndUnescape(v)
-                sink += StringLit(normalized)
+                val normalized = unquoteAndUnescape(value)
+                acc.add(FormatToken.StringLit(normalized))
             }
-            is Boolean -> {
-                sink += Ident(v.toString())
-            }
-            else -> error("Literal no soportado: value='$v' (${v?.let { it::class.simpleName }})")
+
+            else ->
+                error(
+                    "Literal no soportado: value='$value' (${value?.let { it::class.simpleName }})",
+                )
         }
     }
 
@@ -131,22 +258,27 @@ class ASTEmitter(private val cfg: FormatterConfig) {
                             append('\\')
                             i++
                         }
+
                         '"' -> {
                             append('"')
                             i++
                         }
+
                         'n' -> {
                             append('\n')
                             i++
                         }
+
                         't' -> {
                             append('\t')
                             i++
                         }
+
                         'r' -> {
                             append('\r')
                             i++
                         }
+
                         else -> {
                             append(s[i + 1])
                             i++
@@ -158,4 +290,77 @@ class ASTEmitter(private val cfg: FormatterConfig) {
                 i++
             }
         }
+
+    private inner class TokenAccumulator {
+        val tokens: MutableList<FormatToken> = mutableListOf()
+        private var indentLevel = 0
+        private var atLineStart = true
+
+        fun add(token: FormatToken) {
+            when (token) {
+                is FormatToken.NewLine -> {
+                    tokens += token
+                    atLineStart = true
+                    return
+                }
+
+                is FormatToken.Space -> {
+                    if (!atLineStart) {
+                        tokens += token
+                    }
+                    return
+                }
+
+                is FormatToken.Indent -> {
+                    tokens += token
+                    atLineStart = false
+                    return
+                }
+
+                else -> {
+                    ensureIndent()
+                    tokens += token
+                    atLineStart = token is FormatToken.Semicolon && cfg.lineJumpAfterSemicolon
+                }
+            }
+        }
+
+        fun addKeyword(text: String) {
+            add(FormatToken.Keyword(text))
+        }
+
+        fun addSpace() {
+            add(FormatToken.Space)
+        }
+
+        fun newline(times: Int = 1) {
+            if (times <= 0) {
+                return
+            }
+            tokens += FormatToken.NewLine(times)
+            atLineStart = true
+        }
+
+        fun markLineStart() {
+            atLineStart = true
+        }
+
+        fun isAtLineStart(): Boolean = atLineStart
+
+        fun withIndent(block: () -> Unit) {
+            indentLevel++
+            block()
+            indentLevel--
+        }
+
+        private fun ensureIndent() {
+            if (!atLineStart) {
+                return
+            }
+            if (indentLevel > 0) {
+                tokens += FormatToken.Indent(cfg.indentSize * indentLevel)
+            }
+            atLineStart = false
+        }
+    }
 }

--- a/formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt
@@ -1,5 +1,6 @@
 package org.printscript.formatter.render
 
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.formatter.rules.ApplyContext
 import org.printscript.formatter.rules.CodeFormatRule
@@ -36,6 +37,12 @@ class RuleApplier(
                     if (config.lineJumpAfterSemicolon) out.append('\n')
                 }
 
+                is FormatToken.Space -> {
+                    if (out.isNotEmpty() && out.last() != ' ' && out.last() != '\n') {
+                        out.append(' ')
+                    }
+                }
+
                 is FormatToken.Keyword -> {
                     out.append(t.text)
                     val next = ctx.next
@@ -59,6 +66,17 @@ class RuleApplier(
                     val rule = rules.firstOrNull { it.matches(t) }
                     if (rule != null) rule.apply(t, ctx) else out.append(renderRaw(t))
                 }
+
+                is FormatToken.OpenBrace -> {
+                    if (config.braceStyle == BraceStyle.SAME_LINE) {
+                        if (out.isNotEmpty() && out.last() != ' ' && out.last() != '\n') {
+                            out.append(' ')
+                        }
+                    }
+                    out.append('{')
+                }
+
+                is FormatToken.CloseBrace -> out.append('}')
             }
         }
 

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/FormatToken.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/FormatToken.kt
@@ -1,9 +1,9 @@
 package org.printscript.formatter.rules
 
 /**
- * Tokens de FORMATEO (no confundir con tokens del lexer).
+ * Tokens de FORMATEO (NO confundir con tokens del lexer).
  * Los emite el "emitter" a partir del AST del parser.
- * Mantienen semántica (ident, tipo, operadores, etc.) para decidir spacing.
+ * Mantienen semántica (ident, tipo, operadores, etc.) para decidir spacing dsps.
  */
 sealed interface FormatToken {
     // contenido
@@ -16,6 +16,8 @@ sealed interface FormatToken {
     data class NumberLit(val raw: String) : FormatToken
 
     data class StringLit(val raw: String) : FormatToken
+
+    data object Space : FormatToken
 
     // símbolos a los que solemos aplicar reglas
     data object Colon : FormatToken
@@ -31,6 +33,10 @@ sealed interface FormatToken {
     data object OpenParen : FormatToken
 
     data object CloseParen : FormatToken
+
+    data object OpenBrace : FormatToken
+
+    data object CloseBrace : FormatToken
 
     data object Comma : FormatToken
 

--- a/formatter/src/test/kotlin/org/printscript/formatter/ASTEmitterAdditionalTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ASTEmitterAdditionalTest.kt
@@ -1,0 +1,116 @@
+package org.printscript.formatter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.printscript.common.Position
+import org.printscript.formatter.config.BraceStyle
+import org.printscript.formatter.config.FormatterConfig
+import org.printscript.formatter.emit.ASTEmitter
+import org.printscript.formatter.rules.FormatToken
+import org.printscript.parser.node.ASTNode
+import org.printscript.parser.node.EmptyExpressionNode
+import org.printscript.parser.node.ErrorNode
+import org.printscript.parser.node.IfElseNode
+import org.printscript.parser.node.LiteralNode
+import org.printscript.parser.node.PrintStatementNode
+import org.printscript.parser.node.ReadEnvNode
+import org.printscript.parser.node.ReadInputNode
+import org.printscript.parser.node.VariableDeclarationNode
+import org.printscript.token.TokenType
+
+class ASTEmitterAdditionalTest {
+    private fun pos() = Position(1, 1)
+
+    @Test
+    fun `emite readInput y readEnv`() {
+        val readInput = ReadInputNode(LiteralNode("\"Ingresa numero\"", TokenType.STRING), pos())
+        val readEnv = ReadEnvNode(LiteralNode("\"HOME\"", TokenType.STRING), pos())
+        val ast =
+            listOf<ASTNode>(
+                PrintStatementNode(readInput, pos()),
+                PrintStatementNode(readEnv, pos()),
+            )
+        val tokens = ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).emitProgram(ast)
+        val keywordCount = tokens.filterIsInstance<FormatToken.Keyword>().count()
+        assertTrue(keywordCount >= 3) // println, readInput, readEnv
+        assertTrue(tokens.any { it is FormatToken.StringLit && it.raw == "Ingresa numero" })
+        assertTrue(tokens.any { it is FormatToken.StringLit && it.raw == "HOME" })
+    }
+
+    @Test
+    fun `if con then vacio y else con contenido`() {
+        val ifNode =
+            IfElseNode(
+                ifBranch = emptyList(),
+                elseBranch = listOf(PrintStatementNode(LiteralNode("else", TokenType.STRING), pos())),
+                condition = LiteralNode("true", TokenType.TRUE),
+            )
+        val out = ASTEmitter(FormatterConfig(braceStyle = BraceStyle.NEXT_LINE, indentSize = 2)).emitProgram(listOf(ifNode))
+        val openBraceCount = out.count { it is FormatToken.OpenBrace }
+        assertEquals(2, openBraceCount)
+        assertTrue(out.any { it is FormatToken.StringLit && it.raw == "else" })
+    }
+
+    @Test
+    fun `literal con escapes se normaliza`() {
+        val printEscapes = PrintStatementNode(LiteralNode("\"hola\\n\\t\\\"mundo\\\\\"", TokenType.STRING), pos())
+        val tokens = ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).emitProgram(listOf(printEscapes))
+        val stringTok = tokens.filterIsInstance<FormatToken.StringLit>().first()
+        assertTrue(stringTok.raw.contains("\n"))
+        assertTrue(stringTok.raw.contains("\t"))
+    }
+
+    @Test
+    fun `sentencia no soportada lanza error`() {
+        val unsupported = ErrorNode("dummy")
+        val ex =
+            assertThrows(IllegalStateException::class.java) {
+                ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).emitProgram(listOf(unsupported))
+            }
+        assertTrue(ex.message!!.contains("no soportada"))
+    }
+
+    @Test
+    fun `expresion no soportada lanza error`() {
+        // Usamos una declaración como expresión dentro de println para forzar rama de error en emitExpr
+        val declAsExpr = VariableDeclarationNode("a", "number", EmptyExpressionNode, pos())
+        val printBad = PrintStatementNode(declAsExpr, pos())
+        val ex =
+            assertThrows(IllegalStateException::class.java) {
+                ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).emitProgram(listOf(printBad))
+            }
+        assertTrue(ex.message!!.contains("no soportada"))
+    }
+
+    @Test
+    fun `if anidado en else no agrega newline extra al final del bloque interno`() {
+        val inner =
+            IfElseNode(
+                ifBranch = listOf(PrintStatementNode(LiteralNode("inner", TokenType.STRING), pos())),
+                elseBranch = emptyList(),
+                condition = LiteralNode("flag", TokenType.IDENTIFIER),
+            )
+        val outer =
+            IfElseNode(
+                ifBranch = listOf(PrintStatementNode(LiteralNode("outerThen", TokenType.STRING), pos())),
+                elseBranch = listOf(inner),
+                condition = LiteralNode("cond", TokenType.IDENTIFIER),
+            )
+        val tokens = ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE, indentSize = 2)).emitProgram(listOf(outer))
+        // Verificamos que solo haya los braces esperados: 1 if + 1 else + inner if = 3 pares -> 3 open, 3 close
+        val opens = tokens.count { it is FormatToken.OpenBrace }
+        val closes = tokens.count { it is FormatToken.CloseBrace }
+        assertEquals(3, opens)
+        assertEquals(3, closes)
+    }
+
+    @Test
+    fun `escape desconocido se preserva como caracter literal`() {
+        val printStrange = PrintStatementNode(LiteralNode("\"hola\\qfin\"", TokenType.STRING), pos())
+        val tokens = ASTEmitter(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).emitProgram(listOf(printStrange))
+        val str = tokens.filterIsInstance<FormatToken.StringLit>().first().raw
+        assertTrue(str.contains("qfin"))
+    }
+}

--- a/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
@@ -2,11 +2,13 @@ package org.printscript.formatter
 
 import org.junit.jupiter.api.Test
 import org.printscript.common.Position
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.parser.node.AssignationNode
 import org.printscript.parser.node.ConstantDeclarationNode
 import org.printscript.parser.node.DoubleExpressionNode
 import org.printscript.parser.node.EmptyExpressionNode
+import org.printscript.parser.node.IfElseNode
 import org.printscript.parser.node.LiteralNode
 import org.printscript.parser.node.PrintStatementNode
 import org.printscript.parser.node.VariableDeclarationNode
@@ -65,6 +67,7 @@ class CodeFormatterIT {
                 lineJumpBeforePrintln = 0,
                 lineJumpAfterSemicolon = true,
                 indentSize = 4,
+                braceStyle = BraceStyle.SAME_LINE,
             )
 
         val pretty = CodeFormatter().format(ast, cfg)
@@ -95,6 +98,11 @@ class CodeFormatterIT {
                 lineJumpAfterSemicolon = false,
                 spaceAroundEquals = true,
                 spaceAfterColon = true,
+                spaceBeforeColon = false,
+                spaceAroundOperators = true,
+                lineJumpBeforePrintln = 0,
+                indentSize = 4,
+                braceStyle = BraceStyle.SAME_LINE,
             )
         val pretty = CodeFormatter().format(ast, cfg)
         assertEquals("let a: number = 5.0;println(\"a\");", pretty)
@@ -122,7 +130,7 @@ class CodeFormatterIT {
                     pos(),
                 ),
             )
-        val cfg = FormatterConfig()
+        val cfg = FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
 
         val f = CodeFormatter()
         val first = f.format(ast, cfg)
@@ -134,10 +142,60 @@ class CodeFormatterIT {
     fun `declaracion sin inicializador no imprime igual`() {
         val decl = VariableDeclarationNode("name", "string", EmptyExpressionNode, pos())
         val ast = listOf(decl)
-        val cfg = FormatterConfig(spaceAfterColon = true)
+        val cfg = FormatterConfig(spaceAfterColon = true, braceStyle = BraceStyle.SAME_LINE)
 
         val pretty = CodeFormatter().format(ast, cfg)
 
         assertEquals("let name: string;", pretty)
+    }
+
+    @Test
+    fun `if con braces en misma linea`() {
+        val ifNode =
+            IfElseNode(
+                ifBranch = listOf(PrintStatementNode(LiteralNode("then", TokenType.STRING), pos())),
+                elseBranch = listOf(PrintStatementNode(LiteralNode("else", TokenType.STRING), pos())),
+                condition = LiteralNode("flag", TokenType.IDENTIFIER),
+            )
+
+        val cfg =
+            FormatterConfig(
+                braceStyle = BraceStyle.SAME_LINE,
+                indentSize = 4,
+            )
+
+        val pretty = CodeFormatter().format(listOf(ifNode), cfg)
+        val expected =
+            "if (flag) {\n" +
+                "    println(\"then\");\n" +
+                "} else {\n" +
+                "    println(\"else\");\n" +
+                "}"
+        assertEquals(expected, pretty)
+    }
+
+    @Test
+    fun `if con braces debajo e indent custom`() {
+        val ifNode =
+            IfElseNode(
+                ifBranch = listOf(PrintStatementNode(LiteralNode("body", TokenType.STRING), pos())),
+                elseBranch = emptyList(),
+                condition = LiteralNode("cond", TokenType.IDENTIFIER),
+            )
+
+        val cfg =
+            FormatterConfig(
+                braceStyle = BraceStyle.NEXT_LINE,
+                indentSize = 2,
+                lineJumpAfterSemicolon = false,
+            )
+
+        val pretty = CodeFormatter().format(listOf(ifNode), cfg)
+        val expected =
+            "if (cond)\n" +
+                "{\n" +
+                "  println(\"body\");\n" +
+                "}"
+        assertEquals(expected, pretty)
     }
 }

--- a/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
@@ -2,6 +2,7 @@ package org.printscript.formatter
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.ConfigJsonReader
 import java.nio.file.Files
 
@@ -18,7 +19,8 @@ class ConfigJsonReaderTest {
               "spaceAroundOperators": true,
               "lineJumpBeforePrintln": 2,
               "lineJumpAfterSemicolon": false,
-              "indentSize": 2
+              "indentSize": 2,
+              "braceStyle": "next_line"
             }
             """.trimIndent(),
         )
@@ -31,6 +33,7 @@ class ConfigJsonReaderTest {
         assertEquals(2, cfg.lineJumpBeforePrintln)
         assertEquals(false, cfg.lineJumpAfterSemicolon)
         assertEquals(2, cfg.indentSize)
+        assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
     }
 
     @Test
@@ -46,5 +49,22 @@ class ConfigJsonReaderTest {
         assertEquals(0, cfg.lineJumpBeforePrintln)
         assertEquals(true, cfg.lineJumpAfterSemicolon)
         assertEquals(8, cfg.indentSize)
+        assertEquals(BraceStyle.SAME_LINE, cfg.braceStyle)
+    }
+
+    @Test
+    fun `brace style interpreta alias`() {
+        val tmp = Files.createTempFile("fmt-", ".json").toFile()
+        tmp.writeText(
+            """
+            {
+              "braceOnNewLine": true,
+              "ifBraceSameLine": false
+            }
+            """.trimIndent(),
+        )
+
+        val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
+        assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
     }
 }

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
@@ -1,0 +1,55 @@
+package org.printscript.formatter.render
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.printscript.formatter.config.BraceStyle
+import org.printscript.formatter.config.FormatterConfig
+import org.printscript.formatter.rules.FormatToken.CloseBrace
+import org.printscript.formatter.rules.FormatToken.CloseParen
+import org.printscript.formatter.rules.FormatToken.Colon
+import org.printscript.formatter.rules.FormatToken.Ident
+import org.printscript.formatter.rules.FormatToken.Indent
+import org.printscript.formatter.rules.FormatToken.Keyword
+import org.printscript.formatter.rules.FormatToken.NewLine
+import org.printscript.formatter.rules.FormatToken.OpenBrace
+import org.printscript.formatter.rules.FormatToken.OpenParen
+import org.printscript.formatter.rules.FormatToken.Semicolon
+import org.printscript.formatter.rules.FormatToken.Space
+import org.printscript.formatter.rules.FormatToken.StringLit
+import org.printscript.formatter.rules.FormatToken.TypeName
+
+class RuleApplierAdditionalTest {
+    @Test
+    fun `trimming de newlines finales`() {
+        val toks =
+            listOf(
+                Keyword("println"),
+                OpenParen,
+                StringLit("x"),
+                CloseParen,
+                Semicolon,
+                NewLine(2),
+            )
+        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        assertEquals("println(\"x\");", out)
+    }
+
+    @Test
+    fun `space token inicial es ignorado`() {
+        val toks = listOf(Space, Keyword("let"), Space, Ident("a"), Colon, TypeName("number"), Semicolon)
+        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        // Formato esperado con reglas por defecto: no espacio antes de ':', espacio después, salto luego de ';'
+        assertEquals("let a: number;", out)
+    }
+
+    @Test
+    fun `indent token se preserva tras newline`() {
+        val toks =
+            listOf(
+                Keyword("if"), Space, OpenParen, Ident("cond"), CloseParen, Space, OpenBrace, NewLine(),
+                Indent(4), Keyword("println"), OpenParen, StringLit("ok"), CloseParen, Semicolon, CloseBrace,
+            )
+        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        assertEquals("if (cond) {\n    println(\"ok\");\n}", out)
+    }
+}

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
@@ -2,6 +2,7 @@ package org.printscript.formatter.render
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.printscript.formatter.config.BraceStyle
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.formatter.rules.FormatToken
 import org.printscript.formatter.rules.FormatToken.Colon
@@ -17,7 +18,7 @@ import org.printscript.formatter.rules.FormatToken.TypeName
 class RuleApplierTest {
     @Test
     fun `espacios alrededor de '=' on`() {
-        val toks = listOf(FormatToken.Ident("x"), Equals, NumberLit("5.0"), Semicolon)
+        val toks = listOf(Ident("x"), Equals, NumberLit("5.0"), Semicolon)
         val out = RuleApplier(FormatterConfig(spaceAroundEquals = true)).apply(toks)
         assertEquals("x = 5.0;", out)
     }
@@ -35,22 +36,22 @@ class RuleApplierTest {
         val rhs = listOf(TypeName("number"), Semicolon)
 
         val both =
-            RuleApplier(FormatterConfig(spaceBeforeColon = true, spaceAfterColon = true))
+            RuleApplier(FormatterConfig(spaceBeforeColon = true, spaceAfterColon = true, braceStyle = BraceStyle.SAME_LINE))
                 .apply(lhs + Colon + rhs)
         assertEquals("let a : number;", both)
 
         val onlyAfter =
-            RuleApplier(FormatterConfig(spaceBeforeColon = false, spaceAfterColon = true))
+            RuleApplier(FormatterConfig(spaceBeforeColon = false, spaceAfterColon = true, braceStyle = BraceStyle.SAME_LINE))
                 .apply(lhs + Colon + rhs)
         assertEquals("let a: number;", onlyAfter)
 
         val onlyBefore =
-            RuleApplier(FormatterConfig(spaceBeforeColon = true, spaceAfterColon = false))
+            RuleApplier(FormatterConfig(spaceBeforeColon = true, spaceAfterColon = false, braceStyle = BraceStyle.SAME_LINE))
                 .apply(lhs + Colon + rhs)
         assertEquals("let a :number;", onlyBefore)
 
         val none =
-            RuleApplier(FormatterConfig(spaceBeforeColon = false, spaceAfterColon = false))
+            RuleApplier(FormatterConfig(spaceBeforeColon = false, spaceAfterColon = false, braceStyle = BraceStyle.SAME_LINE))
                 .apply(lhs + Colon + rhs)
         assertEquals("let a:number;", none)
     }
@@ -59,21 +60,21 @@ class RuleApplierTest {
     fun `operadores con espacios y deteccion de '-' unario`() {
         // Caso binario: "1 + 2"
         val bin =
-            RuleApplier(FormatterConfig(spaceAroundOperators = true)).apply(
+            RuleApplier(FormatterConfig(spaceAroundOperators = true, braceStyle = BraceStyle.SAME_LINE)).apply(
                 listOf(NumberLit("1.0"), Op(OpKind.PLUS), NumberLit("2.0"), Semicolon),
             )
         assertEquals("1.0 + 2.0;", bin)
 
         // Caso unario tras '=': "x = -1"
         val unary =
-            RuleApplier(FormatterConfig(spaceAroundOperators = true)).apply(
+            RuleApplier(FormatterConfig(spaceAroundOperators = true, braceStyle = BraceStyle.SAME_LINE)).apply(
                 listOf(Ident("x"), Equals, Op(OpKind.MINUS), NumberLit("1.0"), Semicolon),
             )
         assertEquals("x = -1.0;", unary)
 
         // Sin espacios alrededor de operadores
         val noSpaces =
-            RuleApplier(FormatterConfig(spaceAroundOperators = false)).apply(
+            RuleApplier(FormatterConfig(spaceAroundOperators = false, braceStyle = BraceStyle.SAME_LINE)).apply(
                 listOf(NumberLit("3.0"), Op(OpKind.STAR), NumberLit("4.0"), Semicolon),
             )
         assertEquals("3.0*4.0;", noSpaces)
@@ -93,8 +94,58 @@ class RuleApplierTest {
                 Semicolon,
             )
         val out =
-            RuleApplier(FormatterConfig(lineJumpAfterSemicolon = false, spaceAroundEquals = true))
+            RuleApplier(FormatterConfig(lineJumpAfterSemicolon = false, spaceAroundEquals = true, braceStyle = BraceStyle.SAME_LINE))
                 .apply(toks)
         assertEquals("a = 1.0;b = 2.0;", out)
+    }
+
+    @Test
+    fun `open brace same line agrega espacios`() {
+        val toks =
+            listOf(
+                Keyword("if"),
+                FormatToken.Space,
+                FormatToken.OpenParen,
+                NumberLit("1"),
+                FormatToken.CloseParen,
+                FormatToken.Space,
+                FormatToken.OpenBrace,
+                FormatToken.NewLine(),
+                FormatToken.Indent(4),
+                Keyword("println"),
+                FormatToken.OpenParen,
+                FormatToken.StringLit("ok"),
+                FormatToken.CloseParen,
+                Semicolon,
+                FormatToken.CloseBrace,
+            )
+
+        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        assertEquals("if (1) {\n    println(\"ok\");\n}", out)
+    }
+
+    @Test
+    fun `open brace en nueva linea`() {
+        val toks =
+            listOf(
+                Keyword("if"),
+                FormatToken.Space,
+                FormatToken.OpenParen,
+                Ident("cond"),
+                FormatToken.CloseParen,
+                FormatToken.NewLine(),
+                FormatToken.OpenBrace,
+                FormatToken.NewLine(),
+                FormatToken.Indent(2),
+                Ident("x"),
+                Equals,
+                NumberLit("1"),
+                Semicolon,
+                FormatToken.CloseBrace,
+            )
+
+        val out =
+            RuleApplier(FormatterConfig(braceStyle = BraceStyle.NEXT_LINE, indentSize = 2)).apply(toks)
+        assertEquals("if (cond)\n{\n  x = 1;\n}", out)
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the formatter's configuration handling and code emission, focusing on adding flexible brace style support and enhancing configuration parsing robustness. The changes affect how formatting options are read from configuration files, how AST nodes are emitted as format tokens, and how those tokens are rendered into code. The update also introduces a new `BraceStyle` enum, updates the default configuration, and increments the formatter version.

**Key changes:**

### Formatter configuration and parsing

* Introduced a new `BraceStyle` enum with options `SAME_LINE` and `NEXT_LINE`, and added a corresponding `braceStyle` property to `FormatterConfig`. The default is now `SAME_LINE`. (`formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt` [[1]](diffhunk://#diff-9aeaacc5a79e1533a84c87a3b2d3a6e3f1fd6428473e1cdf0dbafe10ba676d87R3-R7) [[2]](diffhunk://#diff-9aeaacc5a79e1533a84c87a3b2d3a6e3f1fd6428473e1cdf0dbafe10ba676d87R16)
* Improved the JSON configuration reader to robustly handle missing, blank, or malformed config files and to flexibly parse various representations of boolean, integer, and brace style options. This includes support for multiple possible key names for brace style and flexible value parsing. (`formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt` [formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.ktL3-R120](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68L3-R120))
* Updated the CLI adapter to use the new `braceStyle` default when no config file is provided. (`cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt` [[1]](diffhunk://#diff-8dd457c8cf7d14b844df0191ac96058c3b3d647dd81233ab3038e57901adb835R4) [[2]](diffhunk://#diff-8dd457c8cf7d14b844df0191ac96058c3b3d647dd81233ab3038e57901adb835L13-R14)

### Formatter emission and rendering

* Refactored the `ASTEmitter` to support emitting blocks with configurable brace placement (`SAME_LINE` or `NEXT_LINE`), and to emit all statements and expressions using a new `TokenAccumulator` helper class for better handling of indentation, spacing, and newlines. (`formatter/src/main/kotlin/org/printscript/formatter/emit/ASTEmitter.kt` [[1]](diffhunk://#diff-0c3e236e822bc3277b0137417583b8d67a1fea884fe72ee53a6a96db1f1807deR3-R236) [[2]](diffhunk://#diff-0c3e236e822bc3277b0137417583b8d67a1fea884fe72ee53a6a96db1f1807deR261-R281) [[3]](diffhunk://#diff-0c3e236e822bc3277b0137417583b8d67a1fea884fe72ee53a6a96db1f1807deR293-R365)
* Updated the `RuleApplier` to render `OpenBrace` and `CloseBrace` tokens according to the configured brace style, ensuring correct spacing and formatting in the output code. (`formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt` [[1]](diffhunk://#diff-e219f585e068d16af4b70e1d7e256a5f58238fb2357b7a7771db1015204b4e58R3) [[2]](diffhunk://#diff-e219f585e068d16af4b70e1d7e256a5f58238fb2357b7a7771db1015204b4e58R40-R45) [[3]](diffhunk://#diff-e219f585e068d16af4b70e1d7e256a5f58238fb2357b7a7771db1015204b4e58R69-R79)

### Tokens and versioning

* Added a new `Space` token to `FormatToken` for explicit space handling during emission and rendering. (`formatter/src/main/kotlin/org/printscript/formatter/rules/FormatToken.kt` [[1]](diffhunk://#diff-4b9880f44e54209d6ca07d5a56b077164ab0657d6ca74ecf39fbbe48562b5a06L4-R6) [[2]](diffhunk://#diff-4b9880f44e54209d6ca07d5a56b077164ab0657d6ca74ecf39fbbe48562b5a06R20-R21)
* Bumped the formatter module version to `1.6-SNAPSHOT`. (`formatter/build.gradle` [formatter/build.gradleL6-R6](diffhunk://#diff-0c3ea61c5b5baf8c519b190b1677556d77f5ee6b9116749aeb9b35b37e0bb951L6-R6))