### PR TITLE
Formatter fixes tck

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.7-SNAPSHOT'
+version = '1.8-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
@@ -5,10 +5,17 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonPrimitive
 import java.io.File
+import kotlin.io.readText
 
 class ConfigJsonReader {
     fun readFromFile(path: String): FormatterConfig {
-        val json = File(path).readText()
+        val json = File(path).takeIf { it.exists() }?.readText().orEmpty()
+        return parse(json)
+    }
+
+    fun read(reader: java.io.Reader): FormatterConfig = parse(reader.readText())
+
+    private fun parse(json: String): FormatterConfig {
         if (json.isBlank()) {
             return FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
         }
@@ -18,39 +25,104 @@ class ConfigJsonReader {
             return FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
         }
 
-        val obj = element.asJsonObject
-        val defaults = FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
-
-        return FormatterConfig(
-            spaceBeforeColon = obj.optBoolean("spaceBeforeColon", "spaceBeforeTypeColon", "spaceBeforeType") ?: defaults.spaceBeforeColon,
-            spaceAfterColon = obj.optBoolean("spaceAfterColon", "spaceAfterTypeColon", "spaceAfterType") ?: defaults.spaceAfterColon,
-            spaceAroundEquals =
-                obj.optBoolean(
-                    "spaceAroundEquals",
-                    "spaceAroundAssignment",
-                    "spaceAroundAssign",
-                ) ?: defaults.spaceAroundEquals,
-            spaceAroundOperators =
-                obj.optBoolean(
-                    "spaceAroundOperators",
-                    "spaceAroundOps",
-                    "spaceAroundBinaryOperators",
-                ) ?: defaults.spaceAroundOperators,
-            lineJumpBeforePrintln =
-                obj.optInt(
-                    "lineJumpBeforePrintln",
-                    "printlnLeadingLineJumps",
-                ) ?: defaults.lineJumpBeforePrintln,
-            lineJumpAfterSemicolon =
-                obj.optBoolean(
-                    "lineJumpAfterSemicolon",
-                    "newlineAfterSemicolon",
-                    "lineBreakAfterStatement",
-                ) ?: defaults.lineJumpAfterSemicolon,
-            indentSize = obj.optInt("indentSize", "indent", "indentSpaces") ?: defaults.indentSize,
-            braceStyle = obj.optBraceStyle() ?: defaults.braceStyle,
-        )
+        return element.asJsonObject.toFormatterConfig()
     }
+}
+
+private fun JsonObject.toFormatterConfig(): FormatterConfig {
+    val defaults = FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
+
+    val singleSpace = optBoolean("mandatory-single-space-separation")
+
+    var spaceBeforeColon = defaults.spaceBeforeColon
+    var spaceAfterColon = defaults.spaceAfterColon
+    var spaceAroundEquals = defaults.spaceAroundEquals
+    var spaceAroundOperators = defaults.spaceAroundOperators
+
+    if (singleSpace == true) {
+        spaceBeforeColon = true
+        spaceAfterColon = true
+        spaceAroundEquals = true
+        spaceAroundOperators = true
+    }
+
+    optBoolean(
+        "spaceBeforeColon",
+        "spaceBeforeTypeColon",
+        "spaceBeforeType",
+        "enforce-spacing-before-colon-in-declaration",
+    )?.let { spaceBeforeColon = it }
+
+    optBoolean(
+        "spaceAfterColon",
+        "spaceAfterTypeColon",
+        "spaceAfterType",
+        "enforce-spacing-after-colon-in-declaration",
+    )?.let { spaceAfterColon = it }
+
+    optBoolean(
+        "spaceAroundEquals",
+        "spaceAroundAssignment",
+        "spaceAroundAssign",
+        "enforce-spacing-around-equals",
+        "enforce-spacing-around-assignment",
+        "mandatory-spacing-around-equals",
+    )?.let { spaceAroundEquals = it }
+
+    optBooleanNegated(
+        "enforce-no-spacing-around-equals",
+        "enforce-no-spacing-around-assignment",
+    )?.let { spaceAroundEquals = it }
+
+    optBoolean(
+        "spaceAroundOperators",
+        "spaceAroundOps",
+        "spaceAroundBinaryOperators",
+        "mandatory-space-surrounding-operations",
+    )?.let { spaceAroundOperators = it }
+
+    val lineJumpBeforePrintln =
+        optInt(
+            "lineJumpBeforePrintln",
+            "printlnLeadingLineJumps",
+            "line-breaks-after-println",
+        ) ?: defaults.lineJumpBeforePrintln
+
+    val lineJumpAfterSemicolon =
+        optBoolean(
+            "lineJumpAfterSemicolon",
+            "newlineAfterSemicolon",
+            "lineBreakAfterStatement",
+            "mandatory-line-break-after-statement",
+        ) ?: defaults.lineJumpAfterSemicolon
+
+    val indentSize =
+        optInt(
+            "indentSize",
+            "indent",
+            "indentSpaces",
+            "indent-inside-if",
+        ) ?: defaults.indentSize
+
+    var braceStyle = optBraceStyle() ?: defaults.braceStyle
+
+    optBoolean("if-brace-same-line", "brace-same-line")?.let {
+        braceStyle = if (it) BraceStyle.SAME_LINE else BraceStyle.NEXT_LINE
+    }
+
+    optBoolean("if-brace-below-line", "if-brace-next-line", "if-brace-new-line", "brace-below-line", "brace-next-line")
+        ?.let { braceStyle = if (it) BraceStyle.NEXT_LINE else BraceStyle.SAME_LINE }
+
+    return FormatterConfig(
+        spaceBeforeColon = spaceBeforeColon,
+        spaceAfterColon = spaceAfterColon,
+        spaceAroundEquals = spaceAroundEquals,
+        spaceAroundOperators = spaceAroundOperators,
+        lineJumpBeforePrintln = lineJumpBeforePrintln,
+        lineJumpAfterSemicolon = lineJumpAfterSemicolon,
+        indentSize = indentSize,
+        braceStyle = braceStyle,
+    )
 }
 
 private fun JsonObject.optBoolean(vararg keys: String): Boolean? {
@@ -60,6 +132,18 @@ private fun JsonObject.optBoolean(vararg keys: String): Boolean? {
         val bool = primitive.asFlexibleBoolean()
         if (bool != null) {
             return bool
+        }
+    }
+    return null
+}
+
+private fun JsonObject.optBooleanNegated(vararg keys: String): Boolean? {
+    for (key in keys) {
+        if (!has(key)) continue
+        val primitive = get(key)?.asPrimitiveOrNull() ?: continue
+        val bool = primitive.asFlexibleBoolean()
+        if (bool != null) {
+            return !bool
         }
     }
     return null
@@ -87,12 +171,20 @@ private fun JsonObject.optBraceStyle(): BraceStyle? {
             "ifBraceStyle",
             "ifBracePosition",
             "ifBraceSameLine",
+            "if-brace-same-line",
             "braceSameLine",
             "braceOnSameLine",
             "braceOnNewLine",
             "braceBelowStatement",
             "braceBelow",
             "braceNextLine",
+            "ifBraceNextLine",
+            "ifBraceNewLine",
+            "if-brace-next-line",
+            "if-brace-new-line",
+            "braceBelowLine",
+            "brace-next-line",
+            "brace-below-line",
         )
 
     for (key in keys) {
@@ -105,6 +197,7 @@ private fun JsonObject.optBraceStyle(): BraceStyle? {
             return when {
                 keyLower.contains("newline") || keyLower.contains("below") || keyLower.contains("nextline") ->
                     if (bool) BraceStyle.NEXT_LINE else BraceStyle.SAME_LINE
+
                 keyLower.contains("sameline") -> if (bool) BraceStyle.SAME_LINE else BraceStyle.NEXT_LINE
                 else -> if (bool) BraceStyle.SAME_LINE else BraceStyle.NEXT_LINE
             }
@@ -122,17 +215,12 @@ private fun JsonObject.optBraceStyle(): BraceStyle? {
     return null
 }
 
+private fun JsonElement.asPrimitiveOrNull(): JsonPrimitive? = this as? JsonPrimitive
+
 private fun JsonPrimitive.asFlexibleBoolean(): Boolean? =
     when {
         isBoolean -> asBoolean
+        isString -> asString.trim().toBooleanStrictOrNull()
         isNumber -> asInt != 0
-        isString ->
-            when (asString.trim().lowercase()) {
-                "true", "1", "yes", "y", "on" -> true
-                "false", "0", "no", "n", "off" -> false
-                else -> null
-            }
         else -> null
     }
-
-private fun JsonElement?.asPrimitiveOrNull(): JsonPrimitive? = if (this is JsonPrimitive) this else null

--- a/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
@@ -67,4 +67,34 @@ class ConfigJsonReaderTest {
         val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
         assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
     }
+
+    @Test
+    fun `interpreta alias de TCK`() {
+        val tmp = Files.createTempFile("fmt-", ".json").toFile()
+        tmp.writeText(
+            """
+            {
+              "mandatory-single-space-separation": true,
+              "enforce-spacing-before-colon-in-declaration": true,
+              "enforce-spacing-after-colon-in-declaration": false,
+              "enforce-no-spacing-around-equals": true,
+              "mandatory-space-surrounding-operations": false,
+              "line-breaks-after-println": 2,
+              "mandatory-line-break-after-statement": false,
+              "indent-inside-if": 2,
+              "if-brace-below-line": true
+            }
+            """.trimIndent(),
+        )
+
+        val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
+        assertEquals(true, cfg.spaceBeforeColon)
+        assertEquals(false, cfg.spaceAfterColon)
+        assertEquals(false, cfg.spaceAroundEquals)
+        assertEquals(false, cfg.spaceAroundOperators)
+        assertEquals(2, cfg.lineJumpBeforePrintln)
+        assertEquals(false, cfg.lineJumpAfterSemicolon)
+        assertEquals(2, cfg.indentSize)
+        assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
+    }
 }


### PR DESCRIPTION
This pull request enhances the flexibility and robustness of the formatter's JSON configuration parsing, making it more compatible with a wider range of configuration schemas and aliases. It introduces support for additional configuration keys, improved handling of missing or blank config files, and more comprehensive test coverage.

**Formatter configuration parsing improvements:**

* Refactored `ConfigJsonReader` to support a wider set of configuration key aliases (including TCK/test suite keys), improved parsing logic for booleans and integers, and added support for negated boolean options (e.g., `"enforce-no-spacing-around-equals"`). Now, multiple synonymous keys are recognized for each config option, and a new `optBooleanNegated` helper was added. [[1]](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68R8-R18) [[2]](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68L21-R125) [[3]](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68R140-R151)
* Extended brace style detection to handle additional key aliases, such as `"if-brace-same-line"`, `"brace-next-line"`, and others, improving compatibility with external configuration files. [[1]](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68R174-R187) [[2]](diffhunk://#diff-da8bc53515d28eeaf783d685dbf570f1740aeb219e5bd8ead64cd51305afbd68R200)
* Improved handling of missing or blank configuration files by defaulting to `BraceStyle.SAME_LINE` and using `.orEmpty()` to avoid exceptions.

**Testing and versioning:**

* Added a comprehensive test (`interpreta alias de TCK`) to verify that all new key aliases and config options are correctly parsed, ensuring compatibility with TCK-style configuration files.
* Updated the project version in `build.gradle` from `1.7-SNAPSHOT` to `1.8-SNAPSHOT` to reflect these enhancements.