### PR TITLE
fix: Update version to 2.2-SNAPSHOT and add tests for space before an…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.1-SNAPSHOT'
+version = '2.2-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -13,8 +13,6 @@ class SpaceAroundColon : CodeFormatRule {
             if (builder.isNotEmpty() && builder.last() != '\n') {
                 builder.append(' ')
             }
-        } else {
-            builder.trimTrailingSpaces()
         }
 
         builder.append(':')

--- a/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
@@ -150,6 +150,50 @@ class CodeFormatterIT {
     }
 
     @Test
+    fun `space before colon rule does not alter trailing spacing`() {
+        val decl =
+            ConstantDeclarationNode(
+                identifier = "value",
+                valueType = "number",
+                expression = LiteralNode(5.0, TokenType.NUMBER),
+                position = pos(),
+            )
+        val cfg =
+            FormatterConfig(
+                spaceBeforeColon = true,
+                spaceAfterColon = false,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+
+        val pretty = CodeFormatter().format(listOf(decl), cfg)
+
+        assertEquals("let value :number = 5;", pretty)
+    }
+
+    @Test
+    fun `space after colon rule preserves leading spacing`() {
+        val decl =
+            ConstantDeclarationNode(
+                identifier = "value",
+                valueType = "number",
+                expression = LiteralNode(5.0, TokenType.NUMBER),
+                position = pos(),
+            )
+        val cfg =
+            FormatterConfig(
+                spaceBeforeColon = false,
+                spaceAfterColon = true,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+
+        val pretty = CodeFormatter().format(listOf(decl), cfg)
+
+        assertEquals("let value: number = 5;", pretty)
+    }
+
+    @Test
     fun `if con braces en misma linea`() {
         val ifNode =
             IfElseNode(


### PR DESCRIPTION
This pull request updates the formatter to version 2.2-SNAPSHOT and improves the handling of spaces around colons in type declarations. It also adds integration tests to ensure the new spacing behavior is correct.

Formatter rule improvements:

* Updated the logic in `SpaceAroundColon` to remove unnecessary trimming of trailing spaces when applying the space-before-colon rule, ensuring that existing spacing is preserved as expected.

Testing enhancements:

* Added integration tests in `CodeFormatterIT` to verify that the space-before-colon rule does not alter trailing spacing and that the space-after-colon rule preserves leading spacing. These tests help prevent regressions and clarify the expected formatting behavior.

Version update:

* Bumped the project version in `build.gradle` from 2.1-SNAPSHOT to 2.2-SNAPSHOT to reflect the new changes.