### PR TITLE
fix: Rename lineJumpBeforePrintln to printLineBreaksAfter for clarity…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.2-SNAPSHOT'
+version = '2.3-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
@@ -7,8 +7,9 @@ package org.printscript.formatter.config
  * - spaceAfterColon: Espacio después de ':' en declaraciones
  * - spaceAroundEquals: Espacio alrededor de '='
  * - spaceAroundOperators: Espacio alrededor de operadores aritméticos
- * - lineJumpBeforePrintln: Saltos de línea que se insertan ANTES de un println (0..2). Alias/compatibilidad con varias claves TCK.
+ * - printLineBreaksAfter: Cantidad de líneas en blanco EXTRA después de cada println (0..2), según TCK.
  * - lineJumpAfterSemicolon: Salto de línea tras ';' para cada sentencia
+ * - singleSpaceSeparation: Un espacio entre tokens visibles (incluye antes de '(', ')' y ';')
  * - indentSize: Cantidad de espacios para indentación en bloques.
  * - braceStyle: Estilo de llaves en bloques if/else (solo v1.1).
  */
@@ -22,7 +23,7 @@ data class FormatterConfig(
     val spaceAfterColon: Boolean = true,
     val spaceAroundEquals: Boolean = true,
     val spaceAroundOperators: Boolean = true,
-    val lineJumpBeforePrintln: Int = 0,
+    val printLineBreaksAfter: Int = 0,
     val singleSpaceSeparation: Boolean = false,
     val lineJumpAfterSemicolon: Boolean = true,
     val indentSize: Int = 4,

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
@@ -95,7 +95,7 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
         singleSpaceSeparation = true
     }
 
-    // 2) Line breaks después de println (TCK: print/println-*-line-breaks-after, line-breaks-after-println)
+    // 2) Line breaks after println (TCK: print/println-*-line-breaks-after, line-breaks-after-println)
     val printLineBreaksAfter =
         pickPrintLineBreaksAfter() // lee print/println-X-line-breaks-after y line-breaks-after-println
             ?: optInt("line-breaks-after-println")

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
@@ -61,18 +61,18 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
             "enforce-spacing-after-colon-in-declaration",
         ) ?: spaceAfterColon
 
-    // equals: soporta 'enforce-equals-spacing' y su opuesto 'enforce-no-spacing-around-equals'
+    // equals: soporta 'enforce-spacing-around-equals' y su opuesto 'enforce-no-spacing-around-equals'
     val equalsProvided =
         hasAny(
             "spaceAroundEquals",
-            "enforce-equals-spacing",
+            "enforce-spacing-around-equals",
             "enforce-no-spacing-around-equals",
         )
     val noEqSpaces = optBoolean("enforce-no-spacing-around-equals")
     spaceAroundEquals =
         when {
             noEqSpaces == true -> false
-            else -> optBoolean("enforce-equals-spacing") ?: spaceAroundEquals
+            else -> optBoolean("enforce-spacing-around-equals") ?: spaceAroundEquals
         }
 
     // operadores: alias TCK
@@ -95,13 +95,12 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
         singleSpaceSeparation = true
     }
 
-    // 2) Line breaks around println (our model: before the println)
-    val directPrintBreaks = this["lineJumpBeforePrintln"]?.asInt
-    val lineJumpBeforePrintln =
+    // 2) Line breaks después de println (TCK: print/println-*-line-breaks-after, line-breaks-after-println)
+    val printLineBreaksAfter =
         pickPrintLineBreaksAfter() // lee print/println-X-line-breaks-after y line-breaks-after-println
-            ?: optInt("print-n-line-breaks-before", "line-breaks-before-println")
-            ?: directPrintBreaks
-            ?: defaults.lineJumpBeforePrintln
+            ?: optInt("line-breaks-after-println")
+            ?: this["lineJumpBeforePrintln"]?.asInt // compat legacy key
+            ?: defaults.printLineBreaksAfter
 
     // 3) Salto de línea luego de ';' (alias TCK + direct key)
     val lineJumpAfterSemicolon =
@@ -137,7 +136,7 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
         spaceAfterColon = spaceAfterColon,
         spaceAroundEquals = spaceAroundEquals,
         spaceAroundOperators = spaceAroundOperators,
-        lineJumpBeforePrintln = lineJumpBeforePrintln,
+        printLineBreaksAfter = printLineBreaksAfter,
         singleSpaceSeparation = singleSpaceSeparation,
         lineJumpAfterSemicolon = lineJumpAfterSemicolon,
         indentSize = indentSize,

--- a/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
@@ -82,7 +82,7 @@ class StatementEmitter(
         expressionEmitter.emit(node.expression, buffer)
         buffer.add(FormatToken.CloseParen)
         buffer.add(FormatToken.Semicolon)
-        // Ahora respetamos lineJumpAfterSemicolon; totalAfter = (1 si está activo) + extras
+        // Now we respect lineJumpAfterSemicolon; totalAfter = (1 if active) + extras
         val base = if (config.lineJumpAfterSemicolon) 1 else 0
         val totalAfter = base + config.printLineBreaksAfter
         if (totalAfter > 0) buffer.newline(totalAfter)

--- a/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
@@ -77,12 +77,15 @@ class StatementEmitter(
         node: PrintStatementNode,
         buffer: TokenBuffer,
     ) {
-        buffer.newline(config.lineJumpBeforePrintln)
         buffer.addKeyword("println")
         buffer.add(FormatToken.OpenParen)
         expressionEmitter.emit(node.expression, buffer)
         buffer.add(FormatToken.CloseParen)
         buffer.add(FormatToken.Semicolon)
+        // Ahora respetamos lineJumpAfterSemicolon; totalAfter = (1 si está activo) + extras
+        val base = if (config.lineJumpAfterSemicolon) 1 else 0
+        val totalAfter = base + config.printLineBreaksAfter
+        if (totalAfter > 0) buffer.newline(totalAfter)
     }
 
     private fun emitIfElse(

--- a/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
@@ -64,7 +64,7 @@ class CodeFormatterIT {
                 spaceAfterColon = true,
                 spaceAroundEquals = true,
                 spaceAroundOperators = true,
-                lineJumpBeforePrintln = 0,
+                printLineBreaksAfter = 0,
                 lineJumpAfterSemicolon = true,
                 indentSize = 4,
                 braceStyle = BraceStyle.SAME_LINE,
@@ -100,7 +100,7 @@ class CodeFormatterIT {
                 spaceAfterColon = true,
                 spaceBeforeColon = false,
                 spaceAroundOperators = true,
-                lineJumpBeforePrintln = 0,
+                printLineBreaksAfter = 0,
                 indentSize = 4,
                 braceStyle = BraceStyle.SAME_LINE,
             )

--- a/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
@@ -32,7 +32,7 @@ class ConfigJsonReaderTest {
         assertEquals(false, cfg.spaceAroundEquals)
         assertEquals(true, cfg.spaceAroundOperators)
         assertEquals(true, cfg.singleSpaceSeparation)
-        assertEquals(2, cfg.lineJumpBeforePrintln)
+        assertEquals(2, cfg.printLineBreaksAfter)
         assertEquals(false, cfg.lineJumpAfterSemicolon)
         assertEquals(2, cfg.indentSize)
         assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
@@ -49,7 +49,7 @@ class ConfigJsonReaderTest {
         assertEquals(true, cfg.spaceAroundEquals)
         assertEquals(true, cfg.spaceAroundOperators)
         assertEquals(false, cfg.singleSpaceSeparation)
-        assertEquals(0, cfg.lineJumpBeforePrintln)
+        assertEquals(0, cfg.printLineBreaksAfter)
         assertEquals(true, cfg.lineJumpAfterSemicolon)
         assertEquals(8, cfg.indentSize)
         assertEquals(BraceStyle.SAME_LINE, cfg.braceStyle)
@@ -97,7 +97,7 @@ class ConfigJsonReaderTest {
         assertEquals(false, cfg.spaceAroundEquals)
         assertEquals(false, cfg.spaceAroundOperators)
         assertEquals(true, cfg.singleSpaceSeparation)
-        assertEquals(2, cfg.lineJumpBeforePrintln)
+        assertEquals(2, cfg.printLineBreaksAfter)
         assertEquals(false, cfg.lineJumpAfterSemicolon)
         assertEquals(2, cfg.indentSize)
         assertEquals(BraceStyle.NEXT_LINE, cfg.braceStyle)
@@ -119,7 +119,7 @@ class ConfigJsonReaderTest {
         )
 
         val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
-        assertEquals(2, cfg.lineJumpBeforePrintln) // Debe tomar el mayor valor true
+        assertEquals(2, cfg.printLineBreaksAfter) // Debe tomar el mayor valor true
         assertEquals(4, cfg.indentSize) // Solo el true
     }
 
@@ -134,7 +134,7 @@ class ConfigJsonReaderTest {
             """.trimIndent(),
         )
         val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
-        assertEquals(1, cfg.lineJumpBeforePrintln)
+        assertEquals(1, cfg.printLineBreaksAfter)
     }
 
     @Test

--- a/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
@@ -119,7 +119,7 @@ class ConfigJsonReaderTest {
         )
 
         val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
-        assertEquals(2, cfg.printLineBreaksAfter) // Debe tomar el mayor valor true
+        assertEquals(2, cfg.printLineBreaksAfter) // Should take the highest true value
         assertEquals(4, cfg.indentSize) // Solo el true
     }
 

--- a/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
@@ -1,0 +1,127 @@
+package org.printscript.formatter
+
+import org.junit.jupiter.api.Test
+import org.printscript.common.Position
+import org.printscript.formatter.config.BraceStyle
+import org.printscript.formatter.config.FormatterConfig
+import org.printscript.parser.node.AssignationNode
+import org.printscript.parser.node.ConstantDeclarationNode
+import org.printscript.parser.node.DoubleExpressionNode
+import org.printscript.parser.node.IfElseNode
+import org.printscript.parser.node.LiteralNode
+import org.printscript.parser.node.PrintStatementNode
+import org.printscript.token.TokenType
+import kotlin.test.assertEquals
+
+class FormatterTKCRulesIT {
+    private fun pos() = Position(1, 1)
+
+    @Test
+    fun `no spacing around equals`() {
+        val decl = ConstantDeclarationNode("a", "number", LiteralNode(5.0, TokenType.NUMBER), pos())
+        val cfg =
+            FormatterConfig(
+                spaceBeforeColon = false,
+                spaceAfterColon = false,
+                spaceAroundEquals = false,
+                spaceAroundOperators = true,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val out = CodeFormatter().format(listOf(decl), cfg)
+        assertEquals("let a:number=5;", out)
+    }
+
+    @Test
+    fun `spacing around equals`() {
+        val decl = ConstantDeclarationNode("a", "number", LiteralNode(5.0, TokenType.NUMBER), pos())
+        val cfg =
+            FormatterConfig(
+                spaceBeforeColon = false,
+                spaceAfterColon = true,
+                spaceAroundEquals = true,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val out = CodeFormatter().format(listOf(decl), cfg)
+        assertEquals("let a: number = 5;", out)
+    }
+
+    @Test
+    fun `single-space separation around parens and semicolon`() {
+        val ast = listOf(PrintStatementNode(LiteralNode("s", TokenType.IDENTIFIER), pos()))
+        val cfg =
+            FormatterConfig(
+                singleSpaceSeparation = true,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val out = CodeFormatter().format(ast, cfg)
+        // Un espacio antes de '(', entre tokens, antes de ')' y antes de ';'
+        assertEquals("println ( s ) ;", out, "Actual='$out'")
+    }
+
+    @Test
+    fun `println inserts extra line breaks after`() {
+        val ast =
+            listOf(
+                PrintStatementNode(LiteralNode("a", TokenType.STRING), pos()),
+                PrintStatementNode(LiteralNode("b", TokenType.STRING), pos()),
+            )
+        val cfg =
+            FormatterConfig(
+                printLineBreaksAfter = 2,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val out = CodeFormatter().format(ast, cfg)
+        // Entre prints debe haber dos líneas en blanco => tres newlines totales tras el primero
+        val expected = "println(\"a\");\n\n\nprintln(\"b\");"
+        assertEquals(expected, out)
+    }
+
+    @Test
+    fun `operators spacing on and off`() {
+        val assign =
+            AssignationNode(
+                variable = "x",
+                expression =
+                    DoubleExpressionNode(
+                        left = LiteralNode(5.0, TokenType.NUMBER),
+                        operator = "+",
+                        right =
+                            DoubleExpressionNode(
+                                left = LiteralNode(4.0, TokenType.NUMBER),
+                                operator = "*",
+                                right =
+                                    DoubleExpressionNode(
+                                        left = LiteralNode(3.0, TokenType.NUMBER),
+                                        operator = "/",
+                                        right = LiteralNode(2.0, TokenType.NUMBER),
+                                        position = pos(),
+                                    ),
+                                position = pos(),
+                            ),
+                        position = pos(),
+                    ),
+                position = pos(),
+            )
+        val on = CodeFormatter().format(listOf(assign), FormatterConfig(spaceAroundOperators = true, lineJumpAfterSemicolon = false))
+        val off = CodeFormatter().format(listOf(assign), FormatterConfig(spaceAroundOperators = false, lineJumpAfterSemicolon = false))
+        assertEquals("x = 5 + 4 * 3 / 2;", on)
+        assertEquals("x = 5+4*3/2;", off)
+    }
+
+    @Test
+    fun `if braces below line`() {
+        val node =
+            IfElseNode(
+                ifBranch = listOf(PrintStatementNode(LiteralNode("then", TokenType.STRING), pos())),
+                elseBranch = listOf(PrintStatementNode(LiteralNode("else", TokenType.STRING), pos())),
+                condition = LiteralNode(true, TokenType.TRUE),
+            )
+        val cfg = FormatterConfig(braceStyle = BraceStyle.NEXT_LINE, indentSize = 2)
+        val out = CodeFormatter().format(listOf(node), cfg)
+        val expected = "if (true)\n{\n  println(\"then\");\n}\nelse\n{\n  println(\"else\");\n}"
+        assertEquals(expected, out)
+    }
+}

--- a/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
@@ -74,7 +74,7 @@ class FormatterTKCRulesIT {
                 braceStyle = BraceStyle.SAME_LINE,
             )
         val out = CodeFormatter().format(ast, cfg)
-        // Entre prints debe haber dos líneas en blanco => tres newlines totales tras el primero
+        // Between prints there should be two blank lines => three total newlines after the first
         val expected = "println(\"a\");\n\n\nprintln(\"b\");"
         assertEquals(expected, out)
     }

--- a/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
@@ -57,7 +57,7 @@ class FormatterTKCRulesIT {
                 braceStyle = BraceStyle.SAME_LINE,
             )
         val out = CodeFormatter().format(ast, cfg)
-        // Un espacio antes de '(', entre tokens, antes de ')' y antes de ';'
+        // One space before '(', between tokens, before ')' and before ';'
         assertEquals("println ( s ) ;", out, "Actual='$out'")
     }
 

--- a/formatter/src/test/kotlin/org/printscript/formatter/emit/ASTEmitterTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/emit/ASTEmitterTest.kt
@@ -71,16 +71,16 @@ class ASTEmitterTest {
             )
         val tokens =
             ASTEmitter(
-                FormatterConfig(lineJumpBeforePrintln = 1, braceStyle = org.printscript.formatter.config.BraceStyle.SAME_LINE),
+                FormatterConfig(printLineBreaksAfter = 1, braceStyle = org.printscript.formatter.config.BraceStyle.SAME_LINE),
             ).emitProgram(ast)
         val expected =
             listOf(
-                FormatToken.NewLine(1),
                 FormatToken.Keyword("println"),
                 FormatToken.OpenParen,
                 FormatToken.StringLit("x"),
                 FormatToken.CloseParen,
                 FormatToken.Semicolon,
+                FormatToken.NewLine(2),
             )
         assertEquals(expected, tokens)
     }


### PR DESCRIPTION
This pull request updates the formatter configuration and its handling of line breaks and spacing rules, improving consistency with TCK (Test Compatibility Kit) standards and clarifying configuration options. The key changes include renaming and reworking the setting for line breaks after `println`, updating related code and tests, and adding a new integration test suite for TCK formatting rules.

**Formatter configuration improvements:**

* The `lineJumpBeforePrintln` option has been renamed and reworked as `printLineBreaksAfter`, now representing the number of extra blank lines after each `println` statement, aligning with TCK naming and behavior. All usages, documentation, and tests have been updated accordingly. [[1]](diffhunk://#diff-9aeaacc5a79e1533a84c87a3b2d3a6e3f1fd6428473e1cdf0dbafe10ba676d87L10-R12) [[2]](diffhunk://#diff-9aeaacc5a79e1533a84c87a3b2d3a6e3f1fd6428473e1cdf0dbafe10ba676d87L25-R26) [[3]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeL98-R103) [[4]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeL140-R139) [[5]](diffhunk://#diff-87199211c62d4d79083153a16f6a7bbecaa1a627f92c98f3ae9c5b7b26901723L80-R88) [[6]](diffhunk://#diff-df066a594a04a1596a6ac384efbc5fd209b31a90b7ebbcf0a4d51d9a51cd9754L67-R67) [[7]](diffhunk://#diff-df066a594a04a1596a6ac384efbc5fd209b31a90b7ebbcf0a4d51d9a51cd9754L103-R103) [[8]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL35-R35) [[9]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL52-R52) [[10]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL100-R100) [[11]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL122-R122) [[12]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL137-R137) [[13]](diffhunk://#diff-64dcc0f059d5cbc25384d1d3d8552870cec89cca9991759f37a01ea9f9a9260eL74-R83)

* The configuration parser now correctly recognizes `enforce-spacing-around-equals` and its negative form, improving compatibility with TCK and clarifying the naming of supported keys.

**Testing and verification:**

* A new integration test suite (`FormatterTKCRulesIT.kt`) has been added to verify formatter behavior against TCK rules, including spacing around equals, operators, parentheses, semicolons, and correct handling of line breaks and brace styles.

**Build versioning:**

* The project version has been bumped from `2.2-SNAPSHOT` to `2.3-SNAPSHOT` in `build.gradle`.…