### PR TITLE
Formatter fixes tck

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.3-SNAPSHOT'
+version = '2.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
@@ -20,12 +20,12 @@ enum class BraceStyle {
 
 data class FormatterConfig(
     val spaceBeforeColon: Boolean = false,
-    val spaceAfterColon: Boolean = true,
-    val spaceAroundEquals: Boolean = true,
-    val spaceAroundOperators: Boolean = true,
+    val spaceAfterColon: Boolean = false,
+    val spaceAroundEquals: Boolean = false,
+    val spaceAroundOperators: Boolean = false,
     val printLineBreaksAfter: Int = 0,
     val singleSpaceSeparation: Boolean = false,
-    val lineJumpAfterSemicolon: Boolean = true,
+    val lineJumpAfterSemicolon: Boolean = false,
     val indentSize: Int = 4,
     val braceStyle: BraceStyle = BraceStyle.SAME_LINE,
 )

--- a/formatter/src/main/kotlin/org/printscript/formatter/render/DefaultTokenRenderer.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/render/DefaultTokenRenderer.kt
@@ -2,6 +2,7 @@ package org.printscript.formatter.render
 
 import org.printscript.formatter.rules.ApplyContext
 import org.printscript.formatter.rules.FormatToken
+import org.printscript.formatter.rules.trimTrailingSpaces
 
 /**
  * Renderizador por defecto para todos los tokens que no tienen una regla
@@ -14,7 +15,12 @@ class DefaultTokenRenderer : FormatTokenRenderer {
         ctx: ApplyContext,
     ) {
         when (token) {
-            is FormatToken.NewLine -> repeat(token.count) { ctx.out.append('\n') }
+            is FormatToken.NewLine -> {
+                repeat(token.count) {
+                    ctx.out.trimTrailingSpaces()
+                    ctx.out.append('\n')
+                }
+            }
             is FormatToken.Indent -> ctx.out.append(" ".repeat(token.spaces))
             is FormatToken.OpenParen -> ctx.out.append('(')
             is FormatToken.CloseParen -> ctx.out.append(')')

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SemicolonLineBreakRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SemicolonLineBreakRule.kt
@@ -14,6 +14,7 @@ class SemicolonLineBreakRule : CodeFormatRule {
         enforceSingleSpaceBefore(t, ctx)
         ctx.out.append(';')
         if (ctx.cfg.lineJumpAfterSemicolon && ctx.next !is FormatToken.NewLine) {
+            ctx.out.trimTrailingSpaces()
             ctx.out.append('\n')
         }
     }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -22,9 +22,3 @@ class SpaceAroundColon : CodeFormatRule {
         }
     }
 }
-
-private fun StringBuilder.trimTrailingSpaces() {
-    while (this.isNotEmpty() && this[this.length - 1] == ' ') {
-        deleteCharAt(this.length - 1)
-    }
-}

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/StringBuilderExtensions.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/StringBuilderExtensions.kt
@@ -1,0 +1,7 @@
+package org.printscript.formatter.rules
+
+internal fun StringBuilder.trimTrailingSpaces() {
+    while (isNotEmpty() && this[length - 1] == ' ') {
+        deleteCharAt(length - 1)
+    }
+}

--- a/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
@@ -162,6 +162,7 @@ class CodeFormatterIT {
             FormatterConfig(
                 spaceBeforeColon = true,
                 spaceAfterColon = false,
+                spaceAroundEquals = true,
                 lineJumpAfterSemicolon = false,
                 braceStyle = BraceStyle.SAME_LINE,
             )
@@ -184,6 +185,7 @@ class CodeFormatterIT {
             FormatterConfig(
                 spaceBeforeColon = false,
                 spaceAfterColon = true,
+                spaceAroundEquals = true,
                 lineJumpAfterSemicolon = false,
                 braceStyle = BraceStyle.SAME_LINE,
             )

--- a/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/ConfigJsonReaderTest.kt
@@ -45,12 +45,12 @@ class ConfigJsonReaderTest {
 
         val cfg = ConfigJsonReader().readFromFile(tmp.absolutePath)
         assertEquals(false, cfg.spaceBeforeColon)
-        assertEquals(true, cfg.spaceAfterColon)
+        assertEquals(false, cfg.spaceAfterColon)
         assertEquals(true, cfg.spaceAroundEquals)
-        assertEquals(true, cfg.spaceAroundOperators)
+        assertEquals(false, cfg.spaceAroundOperators)
         assertEquals(false, cfg.singleSpaceSeparation)
         assertEquals(0, cfg.printLineBreaksAfter)
-        assertEquals(true, cfg.lineJumpAfterSemicolon)
+        assertEquals(false, cfg.lineJumpAfterSemicolon)
         assertEquals(8, cfg.indentSize)
         assertEquals(BraceStyle.SAME_LINE, cfg.braceStyle)
     }

--- a/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
@@ -71,12 +71,42 @@ class FormatterTKCRulesIT {
         val cfg =
             FormatterConfig(
                 printLineBreaksAfter = 2,
+                lineJumpAfterSemicolon = true,
                 braceStyle = BraceStyle.SAME_LINE,
             )
         val out = CodeFormatter().format(ast, cfg)
         // Entre prints debe haber dos líneas en blanco => tres newlines totales tras el primero
         val expected = "println(\"a\");\n\n\nprintln(\"b\");"
         assertEquals(expected, out)
+    }
+
+    @Test
+    fun `println without extra line breaks keeps single separator`() {
+        val ast =
+            listOf(
+                PrintStatementNode(LiteralNode("a", TokenType.STRING), pos()),
+                PrintStatementNode(LiteralNode("b", TokenType.STRING), pos()),
+            )
+        val cfg = FormatterConfig(lineJumpAfterSemicolon = true, braceStyle = BraceStyle.SAME_LINE)
+        val out = CodeFormatter().format(ast, cfg)
+        assertEquals("println(\"a\");\nprintln(\"b\");", out)
+    }
+
+    @Test
+    fun `println with one extra line break`() {
+        val ast =
+            listOf(
+                PrintStatementNode(LiteralNode("a", TokenType.STRING), pos()),
+                PrintStatementNode(LiteralNode("b", TokenType.STRING), pos()),
+            )
+        val cfg =
+            FormatterConfig(
+                printLineBreaksAfter = 1,
+                lineJumpAfterSemicolon = true,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val out = CodeFormatter().format(ast, cfg)
+        assertEquals("println(\"a\");\n\nprintln(\"b\");", out)
     }
 
     @Test
@@ -105,8 +135,24 @@ class FormatterTKCRulesIT {
                     ),
                 position = pos(),
             )
-        val on = CodeFormatter().format(listOf(assign), FormatterConfig(spaceAroundOperators = true, lineJumpAfterSemicolon = false))
-        val off = CodeFormatter().format(listOf(assign), FormatterConfig(spaceAroundOperators = false, lineJumpAfterSemicolon = false))
+        val on =
+            CodeFormatter().format(
+                listOf(assign),
+                FormatterConfig(
+                    spaceAroundOperators = true,
+                    spaceAroundEquals = true,
+                    lineJumpAfterSemicolon = false,
+                ),
+            )
+        val off =
+            CodeFormatter().format(
+                listOf(assign),
+                FormatterConfig(
+                    spaceAroundOperators = false,
+                    spaceAroundEquals = true,
+                    lineJumpAfterSemicolon = false,
+                ),
+            )
         assertEquals("x = 5 + 4 * 3 / 2;", on)
         assertEquals("x = 5+4*3/2;", off)
     }

--- a/formatter/src/test/kotlin/org/printscript/formatter/emit/ASTEmitterTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/emit/ASTEmitterTest.kt
@@ -71,7 +71,11 @@ class ASTEmitterTest {
             )
         val tokens =
             ASTEmitter(
-                FormatterConfig(printLineBreaksAfter = 1, braceStyle = org.printscript.formatter.config.BraceStyle.SAME_LINE),
+                FormatterConfig(
+                    printLineBreaksAfter = 1,
+                    lineJumpAfterSemicolon = true,
+                    braceStyle = org.printscript.formatter.config.BraceStyle.SAME_LINE,
+                ),
             ).emitProgram(ast)
         val expected =
             listOf(

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
@@ -38,8 +38,8 @@ class RuleApplierAdditionalTest {
     fun `space token inicial es ignorado`() {
         val toks = listOf(Space, Keyword("let"), Space, Ident("a"), Colon, TypeName("number"), Semicolon)
         val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
-        // Formato esperado con reglas por defecto: no espacio antes de ':', espacio después, salto luego de ';'
-        assertEquals("let a: number;", out)
+        // Reglas por defecto neutrales: no se insertan espacios adicionales
+        assertEquals("let a:number;", out)
     }
 
     @Test
@@ -49,7 +49,13 @@ class RuleApplierAdditionalTest {
                 Keyword("if"), Space, OpenParen, Ident("cond"), CloseParen, Space, OpenBrace, NewLine(),
                 Indent(4), Keyword("println"), OpenParen, StringLit("ok"), CloseParen, Semicolon, CloseBrace,
             )
-        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        val out =
+            RuleApplier(
+                FormatterConfig(
+                    braceStyle = BraceStyle.SAME_LINE,
+                    lineJumpAfterSemicolon = true,
+                ),
+            ).apply(toks)
         assertEquals("if (cond) {\n    println(\"ok\");\n}", out)
     }
 

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
@@ -67,7 +67,13 @@ class RuleApplierTest {
 
         // Caso unario tras '=': "x = -1"
         val unary =
-            RuleApplier(FormatterConfig(spaceAroundOperators = true, braceStyle = BraceStyle.SAME_LINE)).apply(
+            RuleApplier(
+                FormatterConfig(
+                    spaceAroundOperators = true,
+                    spaceAroundEquals = true,
+                    braceStyle = BraceStyle.SAME_LINE,
+                ),
+            ).apply(
                 listOf(Ident("x"), Equals, Op(OpKind.MINUS), NumberLit("1.0"), Semicolon),
             )
         assertEquals("x = -1.0;", unary)
@@ -120,7 +126,7 @@ class RuleApplierTest {
                 FormatToken.CloseBrace,
             )
 
-        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE)).apply(toks)
+        val out = RuleApplier(FormatterConfig(braceStyle = BraceStyle.SAME_LINE, lineJumpAfterSemicolon = true)).apply(toks)
         assertEquals("if (1) {\n    println(\"ok\");\n}", out)
     }
 
@@ -145,7 +151,14 @@ class RuleApplierTest {
             )
 
         val out =
-            RuleApplier(FormatterConfig(braceStyle = BraceStyle.NEXT_LINE, indentSize = 2)).apply(toks)
+            RuleApplier(
+                FormatterConfig(
+                    braceStyle = BraceStyle.NEXT_LINE,
+                    indentSize = 2,
+                    lineJumpAfterSemicolon = true,
+                    spaceAroundEquals = true,
+                ),
+            ).apply(toks)
         assertEquals("if (cond)\n{\n  x = 1;\n}", out)
     }
 


### PR DESCRIPTION
This pull request updates the formatter's default configuration to use more neutral whitespace settings, improves the handling of trailing spaces before line breaks, and refactors utility code for maintainability. It also updates and expands the test suite to reflect these changes and ensure correct formatting behavior.

**Configuration and Formatting Behavior:**

* Changed the default values in `FormatterConfig` to remove spaces after colons, around equals, around operators, and to disable line jumps after semicolons, making the formatter's output more compact by default.
* Updated related tests and config readers to match the new defaults for whitespace and line break handling. [[1]](diffhunk://#diff-2d32515a2e0419ce5a426d02accb9353f8ae4f2a815af9e5eaea73becc34934bL48-R53) [[2]](diffhunk://#diff-df066a594a04a1596a6ac384efbc5fd209b31a90b7ebbcf0a4d51d9a51cd9754R165) [[3]](diffhunk://#diff-df066a594a04a1596a6ac384efbc5fd209b31a90b7ebbcf0a4d51d9a51cd9754R188)

**Whitespace and Line Break Handling:**

* Improved handling of trailing spaces by ensuring they are trimmed before inserting new lines, both for explicit newlines and after semicolons when line jumps are enabled. [[1]](diffhunk://#diff-469c50c907581b2aaa623db9aa97622e1f164c1dea8b73e2dda2591056b8fe6dL17-R23) [[2]](diffhunk://#diff-fe1d4e46ab9fa2b2459bc2a7162040f348b57d176987270505657adb9a46d4d4R17)
* Moved the `trimTrailingSpaces` extension function to a dedicated file for better code organization and reusability. [[1]](diffhunk://#diff-0c4a404ae5bae1867896cb70c3c28809204b962614ade715e6c9c40bad9d44dbL25-L30) [[2]](diffhunk://#diff-437a1ee50ab1eaa750523886a4fefe2fe749603a4fa4cd74195baff5d8063730R1-R7)

**Testing and Validation:**

* Expanded integration and unit tests to cover new configuration options and ensure correct behavior for line breaks and whitespace, especially around semicolons and operators. [[1]](diffhunk://#diff-e9dadd60494646cb2715d0726daecfbc46b8eb92170cd6e0682a57393b41b7c0R74) [[2]](diffhunk://#diff-e9dadd60494646cb2715d0726daecfbc46b8eb92170cd6e0682a57393b41b7c0R83-R111) [[3]](diffhunk://#diff-e9dadd60494646cb2715d0726daecfbc46b8eb92170cd6e0682a57393b41b7c0L108-R155) [[4]](diffhunk://#diff-64dcc0f059d5cbc25384d1d3d8552870cec89cca9991759f37a01ea9f9a9260eL74-R78) [[5]](diffhunk://#diff-3f1351565b3b6c5f9f7ac2a3719ac2555d7e04e0d61a3f145637939a46fe1b44L52-R58) [[6]](diffhunk://#diff-b703cfb46510662db82bc369c971e4a8b83d783252fc648cd482b624377d325dL70-R76) [[7]](diffhunk://#diff-b703cfb46510662db82bc369c971e4a8b83d783252fc648cd482b624377d325dL123-R129) [[8]](diffhunk://#diff-b703cfb46510662db82bc369c971e4a8b83d783252fc648cd482b624377d325dL148-R161)
* Updated comments and assertions in tests to reflect the new neutral defaults and formatting expectations.

**Versioning:**

* Bumped the project version to `2.4-SNAPSHOT` to reflect these changes.