### PR TITLE
fix: Bump version to 1.4-SNAPSHOT and update default FormatterConfig …

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.3-SNAPSHOT'
+version = '1.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
@@ -11,7 +11,12 @@ class FormatterAdapter {
 
     fun loadConfig(path: String?): FormatterConfig =
         if (path.isNullOrBlank()) {
-            FormatterConfig(braceStyle = BraceStyle.SAME_LINE)
+            FormatterConfig(
+                spaceAfterColon = true,
+                spaceAroundEquals = true,
+                lineJumpAfterSemicolon = true,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
         } else {
             ConfigJsonReader().readFromFile(path)
         }


### PR DESCRIPTION
This pull request includes a version bump for the CLI module and updates the default formatter configuration to enable several code style options by default.

Versioning:

* Updated the project version in `cli/build.gradle` from `1.3-SNAPSHOT` to `1.4-SNAPSHOT` to reflect new changes.

Formatter configuration improvements:

* Modified the `FormatterAdapter`'s `loadConfig` method in `FormatterAdapter.kt` to enable `spaceAfterColon`, `spaceAroundEquals`, and `lineJumpAfterSemicolon` by default when no config file is provided, improving default code formatting behavior.