### PR TITLE
fix: Update spacing rules for operators, equals, and colons; bump ver…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.4-SNAPSHOT'
+version = '2.5-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
@@ -37,10 +37,6 @@ internal fun enforceSingleSpaceBefore(
     val prev = ctx.prev ?: return
     if (token is FormatToken.NewLine || token is FormatToken.Indent || token is FormatToken.Space) return
     if (prev is FormatToken.NewLine || prev is FormatToken.Indent) return
-    if (token is FormatToken.Colon || prev is FormatToken.Colon) return
-    if (token is FormatToken.Equals || prev is FormatToken.Equals) return
-    if (token is FormatToken.Op || prev is FormatToken.Op) return
-    if (token is FormatToken.Comma || prev is FormatToken.Comma) return
 
     val out = ctx.out
     while (out.isNotEmpty() && out[out.length - 1] == ' ') {

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -8,16 +8,17 @@ class SpaceAroundColon : CodeFormatRule {
         ctx: ApplyContext,
     ) {
         val builder = ctx.out
-        if (ctx.cfg.spaceBeforeColon) {
-            builder.trimTrailingSpaces()
-            if (builder.isNotEmpty() && builder.last() != '\n') {
-                builder.append(' ')
-            }
+        val needsSpaceBefore = ctx.cfg.spaceBeforeColon || ctx.cfg.singleSpaceSeparation
+        val needsSpaceAfter = ctx.cfg.spaceAfterColon || ctx.cfg.singleSpaceSeparation
+
+        builder.trimTrailingSpaces()
+        if (needsSpaceBefore && builder.isNotEmpty() && builder.last() != '\n') {
+            builder.append(' ')
         }
 
         builder.append(':')
 
-        if (ctx.cfg.spaceAfterColon) {
+        if (needsSpaceAfter) {
             builder.append(' ')
         }
     }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
@@ -7,6 +7,15 @@ class SpaceAroundEquals : CodeFormatRule {
         t: FormatToken,
         ctx: ApplyContext,
     ) {
-        if (ctx.cfg.spaceAroundEquals) ctx.out.append(" = ") else ctx.out.append("=")
+        val enforceSpacing = ctx.cfg.spaceAroundEquals || ctx.cfg.singleSpaceSeparation
+        if (enforceSpacing) {
+            if (ctx.out.isNotEmpty() && ctx.out.last() != ' ' && ctx.out.last() != '\n') {
+                ctx.out.append(' ')
+            }
+            ctx.out.append('=')
+            ctx.out.append(' ')
+        } else {
+            ctx.out.append('=')
+        }
     }
 }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
@@ -27,12 +27,14 @@ class SpaceAroundOperator : CodeFormatRule {
                 FormatToken.OpKind.SLASH -> "/"
             }
 
-        if (!ctx.cfg.spaceAroundOperators || unaryMinus) {
+        val enforceSpacing = ctx.cfg.spaceAroundOperators || ctx.cfg.singleSpaceSeparation
+
+        if (!enforceSpacing || unaryMinus) {
             ctx.out.append(symbol)
             return
         }
 
-        if (ctx.out.isNotEmpty() && ctx.out.last() != ' ') ctx.out.append(' ')
+        if (ctx.out.isNotEmpty() && ctx.out.last() != ' ' && ctx.out.last() != '\n') ctx.out.append(' ')
         ctx.out.append(symbol)
         ctx.out.append(' ')
     }


### PR DESCRIPTION
This pull request updates the formatter to improve consistency in how spacing rules are applied, especially when the `singleSpaceSeparation` configuration is enabled. The changes ensure that spacing around colons, equals signs, and operators is handled more uniformly, and that the `singleSpaceSeparation` setting takes precedence where appropriate. The project version is also bumped.

**Formatting rule consistency improvements:**

* Updated `SpaceAroundColon`, `SpaceAroundEquals`, and `SpaceAroundOperator` rules to enforce spacing when either their specific config or `singleSpaceSeparation` is enabled, ensuring consistent formatting across different tokens. [[1]](diffhunk://#diff-0c4a404ae5bae1867896cb70c3c28809204b962614ade715e6c9c40bad9d44dbL11-R21) [[2]](diffhunk://#diff-27c57b353f04cc35206a52d9faf0da868ebced2b4cc545c0182c1db97d3f88b7L10-R19) [[3]](diffhunk://#diff-5736dd3cd07c895018861c36c24007b03917e4d88d3d8b48d38a06a66bab5ee4L30-R37)
* Removed special-case exclusions for colons, equals, operators, and commas in `SingleSpaceSeparationRule`, allowing the single space separation logic to apply more broadly.

**Project versioning:**

* Bumped the project version from `2.4-SNAPSHOT` to `2.5-SNAPSHOT` in `build.gradle`.