### PR TITLE
fix: Update spacing rules for colons, equals, and operators; bump ver…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.5-SNAPSHOT'
+version = '2.6-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -8,8 +8,8 @@ class SpaceAroundColon : CodeFormatRule {
         ctx: ApplyContext,
     ) {
         val builder = ctx.out
-        val needsSpaceBefore = ctx.cfg.spaceBeforeColon || ctx.cfg.singleSpaceSeparation
-        val needsSpaceAfter = ctx.cfg.spaceAfterColon || ctx.cfg.singleSpaceSeparation
+        val needsSpaceBefore = ctx.cfg.spaceBeforeColon
+        val needsSpaceAfter = ctx.cfg.spaceAfterColon
 
         builder.trimTrailingSpaces()
         if (needsSpaceBefore && builder.isNotEmpty() && builder.last() != '\n') {

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
@@ -7,8 +7,7 @@ class SpaceAroundEquals : CodeFormatRule {
         t: FormatToken,
         ctx: ApplyContext,
     ) {
-        val enforceSpacing = ctx.cfg.spaceAroundEquals || ctx.cfg.singleSpaceSeparation
-        if (enforceSpacing) {
+        if (ctx.cfg.spaceAroundEquals) {
             if (ctx.out.isNotEmpty() && ctx.out.last() != ' ' && ctx.out.last() != '\n') {
                 ctx.out.append(' ')
             }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
@@ -27,9 +27,7 @@ class SpaceAroundOperator : CodeFormatRule {
                 FormatToken.OpKind.SLASH -> "/"
             }
 
-        val enforceSpacing = ctx.cfg.spaceAroundOperators || ctx.cfg.singleSpaceSeparation
-
-        if (!enforceSpacing || unaryMinus) {
+        if (!ctx.cfg.spaceAroundOperators || unaryMinus) {
             ctx.out.append(symbol)
             return
         }


### PR DESCRIPTION
This pull request updates the code formatting rules in the formatter module to make spacing behavior more consistent and predictable by removing the influence of the `singleSpaceSeparation` configuration from the rules for colons, equals signs, and operators. It also bumps the project version.

Formatter rule changes:

* Updated `SpaceAroundColon`, `SpaceAroundEquals`, and `SpaceAroundOperator` classes to ensure that spacing around colons, equals signs, and operators is determined solely by their respective configuration options (`spaceBeforeColon`, `spaceAfterColon`, `spaceAroundEquals`, `spaceAroundOperators`), and no longer affected by the `singleSpaceSeparation` setting. This makes the formatter's behavior more explicit and easier to configure. [[1]](diffhunk://#diff-0c4a404ae5bae1867896cb70c3c28809204b962614ade715e6c9c40bad9d44dbL11-R12) [[2]](diffhunk://#diff-27c57b353f04cc35206a52d9faf0da868ebced2b4cc545c0182c1db97d3f88b7L10-R10) [[3]](diffhunk://#diff-5736dd3cd07c895018861c36c24007b03917e4d88d3d8b48d38a06a66bab5ee4L30-R30)

Version bump:

* Increased the project version from `2.5-SNAPSHOT` to `2.6-SNAPSHOT` in `build.gradle`.