### PR TITLE
fix: Update formatting rules to preserve original layout; bump versio…

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.4-SNAPSHOT'
+version = '1.5-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt
@@ -24,14 +24,15 @@ class FormatterAdapter {
     fun format(
         ast: List<ASTNode>,
         cfg: FormatterConfig,
-    ): String = formatter.format(ast, cfg)
+        originalSource: String? = null,
+    ): String = formatter.format(ast, cfg, originalSource)
 
     fun check(
         ast: List<ASTNode>,
         cfg: FormatterConfig,
         originalSource: String,
     ): String? {
-        val formatted = format(ast, cfg)
+        val formatted = format(ast, cfg, originalSource)
         return if (formatted == originalSource) null else formatted
     }
 }

--- a/cli/src/main/kotlin/org/printscript/cli/commands/FormatCmd.kt
+++ b/cli/src/main/kotlin/org/printscript/cli/commands/FormatCmd.kt
@@ -42,7 +42,7 @@ class FormatCmd : Callable<Int> {
         return res.fold(
             onSuccess = { ast ->
                 val cfg = fmt.loadConfig(configPath)
-                val formatted = fmt.format(ast, cfg)
+                val formatted = fmt.format(ast, cfg, source)
 
                 if (check) {
                     return if (formatted == source) {

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.6-SNAPSHOT'
+version = '2.7-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/CodeFormatter.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/CodeFormatter.kt
@@ -2,6 +2,7 @@ package org.printscript.formatter
 
 import org.printscript.formatter.config.FormatterConfig
 import org.printscript.formatter.emit.ASTEmitter
+import org.printscript.formatter.layout.OriginalLayoutTracker
 import org.printscript.formatter.render.RuleApplier
 import org.printscript.parser.node.ASTNode
 
@@ -12,8 +13,10 @@ class CodeFormatter(
     fun format(
         program: List<ASTNode>,
         config: FormatterConfig,
+        originalSource: String? = null,
     ): String {
         val tokens = emitterFactory(config).emitProgram(program)
-        return ruleApplierFactory(config).apply(tokens)
+        val layout = originalSource?.let { OriginalLayoutTracker(it) }
+        return ruleApplierFactory(config).apply(tokens, layout)
     }
 }

--- a/formatter/src/main/kotlin/org/printscript/formatter/layout/OriginalLayoutTracker.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/layout/OriginalLayoutTracker.kt
@@ -1,0 +1,106 @@
+package org.printscript.formatter.layout
+
+import org.printscript.formatter.rules.FormatToken
+
+/**
+ * Small helper that walks the original source to capture the whitespace that
+ * surrounded relevant symbols. It purposely ignores any semantic knowledge and
+ * just keeps the raw sequences of whitespace that appeared before and after a
+ * token. The tracker is consumed sequentially while the formatter renders the
+ * emitted tokens.
+ */
+class OriginalLayoutTracker(private val source: String) {
+    data class SurroundingWhitespace(val leading: String, val trailing: String)
+
+    private var index = 0
+
+    fun consume(token: FormatToken): SurroundingWhitespace? =
+        when (token) {
+            is FormatToken.Equals -> consumeChar('=')
+            is FormatToken.Colon -> consumeChar(':')
+            is FormatToken.Semicolon -> consumeChar(';')
+            is FormatToken.Op ->
+                when (token.kind) {
+                    FormatToken.OpKind.PLUS -> consumeChar('+')
+                    FormatToken.OpKind.MINUS -> consumeChar('-')
+                    FormatToken.OpKind.STAR -> consumeChar('*')
+                    FormatToken.OpKind.SLASH -> consumeChar('/')
+                }
+            else -> null
+        }
+
+    private fun consumeChar(target: Char): SurroundingWhitespace? {
+        val pos = findNextChar(target) ?: return null
+
+        val leadingStart = findLeadingStart(pos)
+        val trailingEnd = findTrailingEnd(pos)
+
+        index = pos + 1
+
+        val leading = source.substring(leadingStart, pos)
+        val trailing = source.substring(pos + 1, trailingEnd)
+        return SurroundingWhitespace(leading, trailing)
+    }
+
+    private fun findLeadingStart(pos: Int): Int {
+        var cursor = pos - 1
+        while (cursor >= 0 && source[cursor].isWhitespace()) {
+            cursor--
+        }
+        return cursor + 1
+    }
+
+    private fun findTrailingEnd(pos: Int): Int {
+        var cursor = pos + 1
+        while (cursor < source.length && source[cursor].isWhitespace()) {
+            cursor++
+        }
+        return cursor
+    }
+
+    private fun findNextChar(target: Char): Int? {
+        while (index < source.length) {
+            val current = source[index]
+            when {
+                current == target -> return index
+                current == '\"' -> skipStringLiteral()
+                current == '/' && peekNext() == '/' -> skipSingleLineComment()
+                current == '/' && peekNext() == '*' -> skipBlockComment()
+                else -> index++
+            }
+        }
+        return null
+    }
+
+    private fun skipStringLiteral() {
+        index++ // skip opening quote
+        while (index < source.length) {
+            val c = source[index]
+            if (c == '\\') {
+                index += 2
+                continue
+            }
+            index++
+            if (c == '\"') break
+        }
+    }
+
+    private fun skipSingleLineComment() {
+        while (index < source.length && source[index] != '\n') {
+            index++
+        }
+    }
+
+    private fun skipBlockComment() {
+        index += 2 // skip opening '/*'
+        while (index < source.length) {
+            if (source[index] == '*' && peekNext() == '/') {
+                index += 2
+                break
+            }
+            index++
+        }
+    }
+
+    private fun peekNext(): Char? = if (index + 1 < source.length) source[index + 1] else null
+}

--- a/formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt
@@ -1,6 +1,7 @@
 package org.printscript.formatter.render
 
 import org.printscript.formatter.config.FormatterConfig
+import org.printscript.formatter.layout.OriginalLayoutTracker
 import org.printscript.formatter.rules.ApplyContext
 import org.printscript.formatter.rules.CodeFormatRule
 import org.printscript.formatter.rules.FormatToken
@@ -15,11 +16,21 @@ class RuleApplier(
     private val fallbackRenderer: FormatTokenRenderer = DefaultTokenRenderer(),
     private val rules: List<CodeFormatRule> = DefaultRules.standard(fallbackRenderer),
 ) {
-    fun apply(tokens: List<FormatToken>): String {
+    fun apply(
+        tokens: List<FormatToken>,
+        layout: OriginalLayoutTracker? = null,
+    ): String {
         val out = StringBuilder()
         for (index in tokens.indices) {
             val token = tokens[index]
-            val ctx = ApplyContext(tokens.getOrNull(index - 1), tokens.getOrNull(index + 1), config, out)
+            val ctx =
+                ApplyContext(
+                    prev = tokens.getOrNull(index - 1),
+                    next = tokens.getOrNull(index + 1),
+                    cfg = config,
+                    out = out,
+                    layout = layout,
+                )
             val rule = rules.firstOrNull { it.matches(token) }
             if (rule != null) {
                 rule.apply(token, ctx)

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/CodeFormatRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/CodeFormatRule.kt
@@ -1,12 +1,14 @@
 package org.printscript.formatter.rules
 
 import org.printscript.formatter.config.FormatterConfig
+import org.printscript.formatter.layout.OriginalLayoutTracker
 
 data class ApplyContext(
     val prev: FormatToken?,
     val next: FormatToken?,
     val cfg: FormatterConfig,
     val out: StringBuilder,
+    val layout: OriginalLayoutTracker?,
 )
 
 /** Regla de formateo: decide cómo renderizar un token con su contexto. */

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SemicolonLineBreakRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SemicolonLineBreakRule.kt
@@ -11,11 +11,18 @@ class SemicolonLineBreakRule : CodeFormatRule {
         t: FormatToken,
         ctx: ApplyContext,
     ) {
+        val layoutInfo = ctx.layout?.consume(t)
         enforceSingleSpaceBefore(t, ctx)
         ctx.out.append(';')
+
         if (ctx.cfg.lineJumpAfterSemicolon && ctx.next !is FormatToken.NewLine) {
             ctx.out.trimTrailingSpaces()
             ctx.out.append('\n')
+            return
+        }
+
+        if (!ctx.cfg.lineJumpAfterSemicolon && layoutInfo != null) {
+            ctx.out.append(layoutInfo.trailing)
         }
     }
 }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -10,7 +10,14 @@ class SpaceAroundColon : CodeFormatRule {
         val builder = ctx.out
         val needsSpaceBefore = ctx.cfg.spaceBeforeColon
         val needsSpaceAfter = ctx.cfg.spaceAfterColon
+        val layoutInfo = ctx.layout?.consume(t)
 
+        if (!needsSpaceBefore && !needsSpaceAfter && layoutInfo != null) {
+            builder.append(layoutInfo.leading)
+            builder.append(':')
+            builder.append(layoutInfo.trailing)
+            return
+        }
         builder.trimTrailingSpaces()
         if (needsSpaceBefore && builder.isNotEmpty() && builder.last() != '\n') {
             builder.append(' ')

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
@@ -7,6 +7,7 @@ class SpaceAroundEquals : CodeFormatRule {
         t: FormatToken,
         ctx: ApplyContext,
     ) {
+        val layoutInfo = ctx.layout?.consume(t)
         if (ctx.cfg.spaceAroundEquals) {
             if (ctx.out.isNotEmpty() && ctx.out.last() != ' ' && ctx.out.last() != '\n') {
                 ctx.out.append(' ')
@@ -14,7 +15,13 @@ class SpaceAroundEquals : CodeFormatRule {
             ctx.out.append('=')
             ctx.out.append(' ')
         } else {
-            ctx.out.append('=')
+            if (layoutInfo != null) {
+                ctx.out.append(layoutInfo.leading)
+                ctx.out.append('=')
+                ctx.out.append(layoutInfo.trailing)
+            } else {
+                ctx.out.append('=')
+            }
         }
     }
 }

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt
@@ -26,9 +26,16 @@ class SpaceAroundOperator : CodeFormatRule {
                 FormatToken.OpKind.STAR -> "*"
                 FormatToken.OpKind.SLASH -> "/"
             }
+        val layoutInfo = ctx.layout?.consume(t)
 
         if (!ctx.cfg.spaceAroundOperators || unaryMinus) {
-            ctx.out.append(symbol)
+            if (layoutInfo != null) {
+                ctx.out.append(layoutInfo.leading)
+                ctx.out.append(symbol)
+                ctx.out.append(layoutInfo.trailing)
+            } else {
+                ctx.out.append(symbol)
+            }
             return
         }
 

--- a/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt
@@ -244,4 +244,39 @@ class CodeFormatterIT {
                 "}"
         assertEquals(expected, pretty)
     }
+
+    @Test
+    fun `disabling equals spacing keeps original layout when source is provided`() {
+        val assign = AssignationNode("texto", LiteralNode("valor", TokenType.STRING), pos())
+        val cfg =
+            FormatterConfig(
+                spaceAroundEquals = false,
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+
+        val original = "texto =\"valor\";"
+        val formatted = CodeFormatter().format(listOf(assign), cfg, original)
+
+        assertEquals(original, formatted)
+    }
+
+    @Test
+    fun `disabling semicolon newline preserves original breaks`() {
+        val ast =
+            listOf(
+                PrintStatementNode(LiteralNode("a", TokenType.STRING), pos()),
+                PrintStatementNode(LiteralNode("b", TokenType.STRING), pos()),
+            )
+        val cfg =
+            FormatterConfig(
+                lineJumpAfterSemicolon = false,
+                braceStyle = BraceStyle.SAME_LINE,
+            )
+        val original = "println(\"a\");\nprintln(\"b\");"
+
+        val formatted = CodeFormatter().format(ast, cfg, original)
+
+        assertEquals(original, formatted)
+    }
 }


### PR DESCRIPTION
This pull request introduces a new mechanism to preserve the original whitespace and line breaks around certain symbols (like `=`, `:`, `;`, and operators) in the code formatter when specific formatting options are disabled and the original source is provided. This allows the formatter to better respect the user's original code layout in these scenarios. The update also includes new tests to verify this behavior and increments the project versions.

**Original layout preservation enhancements:**

* Added a new `OriginalLayoutTracker` class to extract and provide the original whitespace around relevant tokens from the source code. This tracker is used during formatting to maintain the user's original layout where appropriate. (`formatter/src/main/kotlin/org/printscript/formatter/layout/OriginalLayoutTracker.kt`)
* Updated the `CodeFormatter` and `RuleApplier` to accept the original source and pass the layout tracker through the formatting pipeline. (`formatter/src/main/kotlin/org/printscript/formatter/CodeFormatter.kt`, `formatter/src/main/kotlin/org/printscript/formatter/render/RuleApplier.kt`) [[1]](diffhunk://#diff-abea2f039bef8f2f0b74bc1163e9217e35f368ae78ae40b5d4179d1b14772106R16-R20) [[2]](diffhunk://#diff-e219f585e068d16af4b70e1d7e256a5f58238fb2357b7a7771db1015204b4e58L18-R33)
* Modified formatting rules for equals, colon, semicolon, and operators to use the original layout when the corresponding spacing or line break options are disabled and the original source is provided. (`formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt`, `formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt`, `formatter/src/main/kotlin/org/printscript/formatter/rules/SemicolonLineBreakRule.kt`, `formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundOperator.kt`) [[1]](diffhunk://#diff-27c57b353f04cc35206a52d9faf0da868ebced2b4cc545c0182c1db97d3f88b7R10-R24) [[2]](diffhunk://#diff-0c4a404ae5bae1867896cb70c3c28809204b962614ade715e6c9c40bad9d44dbR13-R20) [[3]](diffhunk://#diff-fe1d4e46ab9fa2b2459bc2a7162040f348b57d176987270505657adb9a46d4d4R14-R25) [[4]](diffhunk://#diff-5736dd3cd07c895018861c36c24007b03917e4d88d3d8b48d38a06a66bab5ee4R29-R38)

**CLI and adapter updates:**

* Updated the CLI and formatter adapter to allow passing the original source to the formatter, ensuring the new layout preservation features are accessible from the command line. (`cli/src/main/kotlin/org/printscript/cli/adapters/FormatterAdapter.kt`, `cli/src/main/kotlin/org/printscript/cli/commands/FormatCmd.kt`) [[1]](diffhunk://#diff-8dd457c8cf7d14b844df0191ac96058c3b3d647dd81233ab3038e57901adb835L27-R35) [[2]](diffhunk://#diff-5878c30a00b43248caf0b268edcc63ae53f3c156ce413fbeb554466b7bbd0de3L45-R45)

**Testing and versioning:**

* Added integration tests to verify that disabling certain formatting options preserves the original layout when the source is provided. (`formatter/src/test/kotlin/org/printscript/formatter/CodeFormatterIT.kt`)
* Bumped project versions in `build.gradle` files to reflect these changes. (`cli/build.gradle`, `formatter/build.gradle`) [[1]](diffhunk://#diff-de8fe44d5ac06e1637fb405beaa31259f0a95163399c0f8cb4158c820b9efcd0L7-R7) [[2]](diffhunk://#diff-0c3ea61c5b5baf8c519b190b1677556d77f5ee6b9116749aeb9b35b37e0bb951L6-R6)