### PR TITLE
chore: Bump version to 2.8-SNAPSHOT and add explicit spacing policy f…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.7-SNAPSHOT'
+version = '2.8-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
@@ -22,6 +22,11 @@ data class FormatterConfig(
     val spaceBeforeColon: Boolean = false,
     val spaceAfterColon: Boolean = false,
     val spaceAroundEquals: Boolean = false,
+    // Nullable flag that indicates the JSON explicitly requested a policy for '=' spacing.
+    // null -> no explicit request (preserve original layout when available)
+    // true -> enforce spaces around '='
+    // false -> enforce no spaces around '='
+    val spaceAroundEqualsExplicit: Boolean? = null,
     val spaceAroundOperators: Boolean = false,
     val printLineBreaksAfter: Int = 0,
     val singleSpaceSeparation: Boolean = false,

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
@@ -19,6 +19,7 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
     var spaceBeforeColon = this["spaceBeforeColon"]?.asBoolean ?: defaults.spaceBeforeColon
     var spaceAfterColon = this["spaceAfterColon"]?.asBoolean ?: defaults.spaceAfterColon
     var spaceAroundEquals = this["spaceAroundEquals"]?.asBoolean ?: defaults.spaceAroundEquals
+    var spaceAroundEqualsExplicit: Boolean? = null
     var spaceAroundOperators = this["spaceAroundOperators"]?.asBoolean ?: defaults.spaceAroundOperators
     var singleSpaceSeparation =
         this["singleSpaceSeparation"]?.asBoolean
@@ -74,6 +75,16 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
             noEqSpaces == true -> false
             else -> optBoolean("enforce-spacing-around-equals") ?: spaceAroundEquals
         }
+    // Track explicit intent if any of the equals keys were provided
+    if (equalsProvided) {
+        spaceAroundEqualsExplicit =
+            when {
+                noEqSpaces == true -> false
+                optBoolean("enforce-spacing-around-equals") == true -> true
+                this.has("spaceAroundEquals") -> this["spaceAroundEquals"].asBoolean
+                else -> null
+            }
+    }
 
     // operadores: alias TCK
     val operatorsProvided =
@@ -135,6 +146,7 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
         spaceBeforeColon = spaceBeforeColon,
         spaceAfterColon = spaceAfterColon,
         spaceAroundEquals = spaceAroundEquals,
+        spaceAroundEqualsExplicit = spaceAroundEqualsExplicit,
         spaceAroundOperators = spaceAroundOperators,
         printLineBreaksAfter = printLineBreaksAfter,
         singleSpaceSeparation = singleSpaceSeparation,

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
@@ -8,7 +8,9 @@ class SpaceAroundEquals : CodeFormatRule {
         ctx: ApplyContext,
     ) {
         val layoutInfo = ctx.layout?.consume(t)
-        if (ctx.cfg.spaceAroundEquals) {
+        // If the config explicitly required a policy for '=', enforce it regardless of layout.
+        val explicit = ctx.cfg.spaceAroundEqualsExplicit
+        if ((explicit ?: ctx.cfg.spaceAroundEquals)) {
             if (ctx.out.isNotEmpty() && ctx.out.last() != ' ' && ctx.out.last() != '\n') {
                 ctx.out.append(' ')
             }


### PR DESCRIPTION
This pull request updates the formatter configuration to better handle explicit user intent regarding spacing around the equals sign (`=`). It introduces a new configuration flag to distinguish between default behavior and explicit requests, and updates the parsing and enforcement logic accordingly.

**Formatter configuration enhancements:**

* Added a nullable `spaceAroundEqualsExplicit` flag to `FormatterConfig` to indicate if the user explicitly requested a spacing policy for `=` in the JSON config. This allows the formatter to preserve the original layout when no explicit preference is given.
* Updated the JSON config parser (`toFormatterConfig`) to detect and set the `spaceAroundEqualsExplicit` flag based on the presence of relevant keys in the configuration. [[1]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR22) [[2]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR78-R87) [[3]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR149)

**Formatting rule logic:**

* Modified the `SpaceAroundEquals` rule to prioritize the new `spaceAroundEqualsExplicit` flag over the default `spaceAroundEquals` setting, ensuring explicit user intent is respected during formatting.

**Versioning:**

* Bumped the project version from `2.7-SNAPSHOT` to `2.8-SNAPSHOT` to reflect the new configuration capability.