### PR TITLE
Formatter fixes tck

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.8-SNAPSHOT'
+version = '2.9-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundEquals.kt
@@ -9,7 +9,7 @@ class SpaceAroundEquals : CodeFormatRule {
     ) {
         val layoutInfo = ctx.layout?.consume(t)
         val explicit = ctx.cfg.spaceAroundEqualsExplicit
-        
+
         when {
             // Explicitly requested no spaces around '=' - force no spaces
             explicit == false -> {


### PR DESCRIPTION
This pull request updates the `SpaceAroundEquals` code formatting rule to provide clearer and more explicit handling of spaces around the equals sign (`=`), based on configuration settings. It also increments the project version to reflect these changes.

Formatting rule improvements:

* Updated the `SpaceAroundEquals` rule in `SpaceAroundEquals.kt` to explicitly handle all cases: always no spaces, always spaces, or default behavior, based on the `spaceAroundEqualsExplicit` configuration. This ensures the formatter strictly follows user intent when the setting is provided, and falls back to previous behavior otherwise. [[1]](diffhunk://#diff-27c57b353f04cc35206a52d9faf0da868ebced2b4cc545c0182c1db97d3f88b7L11-R28) [[2]](diffhunk://#diff-27c57b353f04cc35206a52d9faf0da868ebced2b4cc545c0182c1db97d3f88b7R45-R46)

Project version update:

* Bumped the project version in `build.gradle` from `2.8-SNAPSHOT` to `2.9-SNAPSHOT` to mark the new release with these formatting improvements.