### PR TITLE
chore: Bump version to 3.0-SNAPSHOT and enhance FormatterConfig with …

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.9-SNAPSHOT'
+version = '3.0-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfig.kt
@@ -22,11 +22,14 @@ data class FormatterConfig(
     val spaceBeforeColon: Boolean = false,
     val spaceAfterColon: Boolean = false,
     val spaceAroundEquals: Boolean = false,
-    // Nullable flag that indicates the JSON explicitly requested a policy for '=' spacing.
+    // Nullable flags that indicate the JSON explicitly requested a policy for spacing.
     // null -> no explicit request (preserve original layout when available)
-    // true -> enforce spaces around '='
-    // false -> enforce no spaces around '='
+    // true -> enforce spaces
+    // false -> enforce no spaces
+    val spaceBeforeColonExplicit: Boolean? = null,
+    val spaceAfterColonExplicit: Boolean? = null,
     val spaceAroundEqualsExplicit: Boolean? = null,
+    val singleSpaceSeparationExplicit: Boolean? = null,
     val spaceAroundOperators: Boolean = false,
     val printLineBreaksAfter: Int = 0,
     val singleSpaceSeparation: Boolean = false,

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/FormatterConfigParser.kt
@@ -20,6 +20,9 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
     var spaceAfterColon = this["spaceAfterColon"]?.asBoolean ?: defaults.spaceAfterColon
     var spaceAroundEquals = this["spaceAroundEquals"]?.asBoolean ?: defaults.spaceAroundEquals
     var spaceAroundEqualsExplicit: Boolean? = null
+    var spaceBeforeColonExplicit: Boolean? = null
+    var spaceAfterColonExplicit: Boolean? = null
+    var singleSpaceSeparationExplicit: Boolean? = null
     var spaceAroundOperators = this["spaceAroundOperators"]?.asBoolean ?: defaults.spaceAroundOperators
     var singleSpaceSeparation =
         this["singleSpaceSeparation"]?.asBoolean
@@ -36,6 +39,20 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
     singleSpaceSeparation =
         optBoolean("enforce-single-space-separation", "mandatory-single-space-separation")
             ?: singleSpaceSeparation
+
+    // Track explicit single space separation request
+    val singleSpaceProvided =
+        hasAny(
+            "singleSpaceSeparation",
+            "enforceSingleSpaceSeparation",
+            "enforce-single-space-separation",
+            "mandatory-single-space-separation",
+        )
+    if (singleSpaceProvided) {
+        singleSpaceSeparationExplicit = optBoolean("enforce-single-space-separation", "mandatory-single-space-separation")
+            ?: this["singleSpaceSeparation"]?.asBoolean
+            ?: this["enforceSingleSpaceSeparation"]?.asBoolean
+    }
 
     // TCK aliases for ':'
     val beforeColonProvided =
@@ -61,6 +78,20 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
             "enforce-decl-spacing-after-colon",
             "enforce-spacing-after-colon-in-declaration",
         ) ?: spaceAfterColon
+
+    // Track explicit colon spacing requests
+    if (beforeColonProvided) {
+        spaceBeforeColonExplicit = optBoolean(
+            "enforce-decl-spacing-before-colon",
+            "enforce-spacing-before-colon-in-declaration",
+        ) ?: this["spaceBeforeColon"]?.asBoolean
+    }
+    if (afterColonProvided) {
+        spaceAfterColonExplicit = optBoolean(
+            "enforce-decl-spacing-after-colon",
+            "enforce-spacing-after-colon-in-declaration",
+        ) ?: this["spaceAfterColon"]?.asBoolean
+    }
 
     // equals: soporta 'enforce-spacing-around-equals' y su opuesto 'enforce-no-spacing-around-equals'
     val equalsProvided =
@@ -146,7 +177,10 @@ internal fun JsonObject.toFormatterConfig(): FormatterConfig {
         spaceBeforeColon = spaceBeforeColon,
         spaceAfterColon = spaceAfterColon,
         spaceAroundEquals = spaceAroundEquals,
+        spaceBeforeColonExplicit = spaceBeforeColonExplicit,
+        spaceAfterColonExplicit = spaceAfterColonExplicit,
         spaceAroundEqualsExplicit = spaceAroundEqualsExplicit,
+        singleSpaceSeparationExplicit = singleSpaceSeparationExplicit,
         spaceAroundOperators = spaceAroundOperators,
         printLineBreaksAfter = printLineBreaksAfter,
         singleSpaceSeparation = singleSpaceSeparation,

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
@@ -32,7 +32,9 @@ internal fun enforceSingleSpaceBefore(
     token: FormatToken,
     ctx: ApplyContext,
 ) {
-    if (!ctx.cfg.singleSpaceSeparation) return
+    // Check explicit request first, then fall back to default
+    val shouldEnforce = ctx.cfg.singleSpaceSeparationExplicit ?: ctx.cfg.singleSpaceSeparation
+    if (!shouldEnforce) return
 
     val prev = ctx.prev ?: return
     if (token is FormatToken.NewLine || token is FormatToken.Indent || token is FormatToken.Space) return

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -8,16 +8,23 @@ class SpaceAroundColon : CodeFormatRule {
         ctx: ApplyContext,
     ) {
         val builder = ctx.out
-        val needsSpaceBefore = ctx.cfg.spaceBeforeColon
-        val needsSpaceAfter = ctx.cfg.spaceAfterColon
         val layoutInfo = ctx.layout?.consume(t)
 
-        if (!needsSpaceBefore && !needsSpaceAfter && layoutInfo != null) {
+        // Check for explicit requests first
+        val explicitBefore = ctx.cfg.spaceBeforeColonExplicit
+        val explicitAfter = ctx.cfg.spaceAfterColonExplicit
+
+        val needsSpaceBefore = explicitBefore ?: ctx.cfg.spaceBeforeColon
+        val needsSpaceAfter = explicitAfter ?: ctx.cfg.spaceAfterColon
+
+        // If no explicit request and layout available, preserve original spacing
+        if (explicitBefore == null && explicitAfter == null && !needsSpaceBefore && !needsSpaceAfter && layoutInfo != null) {
             builder.append(layoutInfo.leading)
             builder.append(':')
             builder.append(layoutInfo.trailing)
             return
         }
+
         builder.trimTrailingSpaces()
         if (needsSpaceBefore && builder.isNotEmpty() && builder.last() != '\n') {
             builder.append(' ')


### PR DESCRIPTION
This pull request introduces support for more granular and explicit control over whitespace formatting in the formatter configuration, particularly around colons and single-space separation. It does so by adding new explicit configuration flags, updating the parser to detect and set these flags, and modifying the relevant formatting rules to honor explicit requests over defaults or layout preservation. The version is also bumped to `3.0-SNAPSHOT`.

**Formatter configuration enhancements:**

* Added new explicit boolean flags to `FormatterConfig` for `spaceBeforeColonExplicit`, `spaceAfterColonExplicit`, and `singleSpaceSeparationExplicit`, allowing users to specify when whitespace rules should be enforced rather than inferred or preserved.
* Updated the configuration parser (`FormatterConfigParser.kt`) to detect when these explicit flags are set in the JSON config and to pass them through to the formatter configuration. [[1]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR23-R25) [[2]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR43-R56) [[3]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR82-R95) [[4]](diffhunk://#diff-63f5057ccafb53059842672718ad4921171bbb23b66d847e6ab407d9f80457aeR180-R183)

**Formatting rule changes:**

* Modified `SingleSpaceSeparationRule` and `SpaceAroundColon` rules to check for explicit whitespace requests first, falling back to the default or layout only if no explicit instruction is present. This ensures that user intent in configuration is always respected. [[1]](diffhunk://#diff-cd6660f0f83545df424d3769a6fe11b8c7e333d92a093325fc5ef5382c85140cL35-R37) [[2]](diffhunk://#diff-0c4a404ae5bae1867896cb70c3c28809204b962614ade715e6c9c40bad9d44dbL11-R27)

**Versioning:**

* Bumped the formatter project version from `2.9-SNAPSHOT` to `3.0-SNAPSHOT` to reflect these breaking and feature changes.