### PR TITLE
Formatter fixes tck

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '3.0-SNAPSHOT'
+version = '3.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
@@ -1,4 +1,3 @@
-// formatter/src/main/kotlin/org/printscript/formatter/config/ConfigJsonReader.kt
 package org.printscript.formatter.config
 
 import java.io.File

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SingleSpaceSeparationRule.kt
@@ -37,7 +37,7 @@ internal fun enforceSingleSpaceBefore(
     if (!shouldEnforce) return
 
     val prev = ctx.prev ?: return
-    if (token is FormatToken.NewLine || token is FormatToken.Indent || token is FormatToken.Space) return
+    if (token is FormatToken.NewLine || token is FormatToken.Indent || token is FormatToken.Space || token is FormatToken.Semicolon) return
     if (prev is FormatToken.NewLine || prev is FormatToken.Indent) return
 
     val out = ctx.out

--- a/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/rules/SpaceAroundColon.kt
@@ -14,26 +14,81 @@ class SpaceAroundColon : CodeFormatRule {
         val explicitBefore = ctx.cfg.spaceBeforeColonExplicit
         val explicitAfter = ctx.cfg.spaceAfterColonExplicit
 
-        val needsSpaceBefore = explicitBefore ?: ctx.cfg.spaceBeforeColon
-        val needsSpaceAfter = explicitAfter ?: ctx.cfg.spaceAfterColon
-
-        // If no explicit request and layout available, preserve original spacing
-        if (explicitBefore == null && explicitAfter == null && !needsSpaceBefore && !needsSpaceAfter && layoutInfo != null) {
-            builder.append(layoutInfo.leading)
-            builder.append(':')
-            builder.append(layoutInfo.trailing)
-            return
-        }
-
-        builder.trimTrailingSpaces()
-        if (needsSpaceBefore && builder.isNotEmpty() && builder.last() != '\n') {
-            builder.append(' ')
-        }
-
-        builder.append(':')
-
-        if (needsSpaceAfter) {
-            builder.append(' ')
+        // When there's an explicit request, ALWAYS enforce it
+        when {
+            explicitBefore != null && explicitAfter != null -> {
+                // Both before and after are explicitly set
+                builder.trimTrailingSpaces()
+                if (explicitBefore && builder.isNotEmpty() && builder.last() != '\n') {
+                    builder.append(' ')
+                }
+                builder.append(':')
+                if (explicitAfter) {
+                    builder.append(' ')
+                }
+            }
+            explicitBefore != null -> {
+                // Only before is explicitly set
+                builder.trimTrailingSpaces()
+                if (explicitBefore && builder.isNotEmpty() && builder.last() != '\n') {
+                    builder.append(' ')
+                }
+                builder.append(':')
+                // For after, preserve layout if available, otherwise use default
+                if (layoutInfo != null) {
+                    builder.append(layoutInfo.trailing)
+                } else if (ctx.cfg.spaceAfterColon) {
+                    builder.append(' ')
+                }
+            }
+            explicitAfter != null -> {
+                // Only after is explicitly set
+                // For before, preserve layout if available, otherwise use default
+                if (layoutInfo != null) {
+                    builder.append(layoutInfo.leading)
+                } else {
+                    builder.trimTrailingSpaces()
+                    if (ctx.cfg.spaceBeforeColon && builder.isNotEmpty() && builder.last() != '\n') {
+                        builder.append(' ')
+                    }
+                }
+                builder.append(':')
+                if (explicitAfter) {
+                    builder.append(' ')
+                }
+            }
+            layoutInfo != null -> {
+                // No explicit requests but have layout - check if config differs from defaults
+                // If config has non-default values, use them; otherwise preserve layout
+                val hasNonDefaultConfig = ctx.cfg.spaceBeforeColon || ctx.cfg.spaceAfterColon
+                if (hasNonDefaultConfig) {
+                    // Use config values instead of preserving layout
+                    builder.trimTrailingSpaces()
+                    if (ctx.cfg.spaceBeforeColon && builder.isNotEmpty() && builder.last() != '\n') {
+                        builder.append(' ')
+                    }
+                    builder.append(':')
+                    if (ctx.cfg.spaceAfterColon) {
+                        builder.append(' ')
+                    }
+                } else {
+                    // Preserve original layout
+                    builder.append(layoutInfo.leading)
+                    builder.append(':')
+                    builder.append(layoutInfo.trailing)
+                }
+            }
+            else -> {
+                // No explicit requests and no layout - use default behavior
+                builder.trimTrailingSpaces()
+                if (ctx.cfg.spaceBeforeColon && builder.isNotEmpty() && builder.last() != '\n') {
+                    builder.append(' ')
+                }
+                builder.append(':')
+                if (ctx.cfg.spaceAfterColon) {
+                    builder.append(' ')
+                }
+            }
         }
     }
 }

--- a/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/FormatterTKCRulesIT.kt
@@ -57,8 +57,8 @@ class FormatterTKCRulesIT {
                 braceStyle = BraceStyle.SAME_LINE,
             )
         val out = CodeFormatter().format(ast, cfg)
-        // One space before '(', between tokens, before ')' and before ';'
-        assertEquals("println ( s ) ;", out, "Actual='$out'")
+        // One space before '(', between tokens, before ')'; semicolon stays attached
+        assertEquals("println ( s );", out, "Actual='$out'")
     }
 
     @Test

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierAdditionalTest.kt
@@ -66,6 +66,6 @@ class RuleApplierAdditionalTest {
 
         val out = RuleApplier(cfg).apply(toks)
 
-        assertEquals("println ( \"a b\" ) ;", out)
+        assertEquals("println ( \"a b\" );", out)
     }
 }

--- a/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
+++ b/formatter/src/test/kotlin/org/printscript/formatter/render/RuleApplierTest.kt
@@ -169,6 +169,6 @@ class RuleApplierTest {
 
         val out = RuleApplier(cfg).apply(toks)
 
-        assertEquals("println ( value ) ;", out)
+        assertEquals("println ( value );", out)
     }
 }


### PR DESCRIPTION
This pull request updates the formatter to improve configuration options and handling of spaces around colons and semicolons. The changes focus on making formatting behavior more predictable and configurable, especially regarding explicit spacing settings and semicolon handling.

**Formatting rules and configuration improvements:**

* Enhanced logic in `SpaceAroundColon` to always enforce explicit spacing requests for colons, with nuanced handling when only one side is specified, and to better preserve or override layout based on configuration (`SpaceAroundColon.kt`).
* Updated the single space separation rule to avoid enforcing a space before semicolons, ensuring semicolons remain attached to the preceding token (`SingleSpaceSeparationRule.kt`).

**Testing and versioning:**

* Adjusted a test assertion to reflect the new behavior where semicolons are not preceded by a space (`FormatterTKCRulesIT.kt`).
* Bumped the project version from `3.0-SNAPSHOT` to `3.1-SNAPSHOT` in `build.gradle`.

**Minor cleanup:**

* Removed a redundant file comment from `ConfigJsonReader.kt`.