### PR TITLE
chore: Bump version to 3.2-SNAPSHOT and update newline handling in St…

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '3.1-SNAPSHOT'
+version = '3.2-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
+++ b/formatter/src/main/kotlin/org/printscript/formatter/emit/StatementEmitter.kt
@@ -121,7 +121,7 @@ class StatementEmitter(
         if (!isLastInBlock) {
             buffer.newline()
         } else {
-            buffer.markLineStart()
+            buffer.newline()
         }
     }
 


### PR DESCRIPTION
This pull request introduces a minor version bump and a small formatting logic update in the formatter module.

- Version Update:
  * Updated the project version from `3.1-SNAPSHOT` to `3.2-SNAPSHOT` in `build.gradle`, signaling a new release with changes.

- Formatting Logic:
  * In `StatementEmitter.kt`, changed the behavior so that the buffer always inserts a newline at the end of a block, rather than marking the line start, ensuring consistent formatting output.