### PR TITLE
fix: Update project versions in build.gradle to remove SNAPSHOT suffix

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.5'
 
 repositories {
     mavenCentral()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.2-SNAPSHOT'
+version = '1.2'
 
 repositories {
     mavenCentral()

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '3.2-SNAPSHOT'
+version = '3.2'
 
 repositories {
     mavenCentral()

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '2.1-SNAPSHOT'
+version = '2.1'
 
 repositories {
     mavenCentral()

--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.6-SNAPSHOT'
+version = '1.6'
 
 repositories { mavenCentral() }
 

--- a/linter/build.gradle
+++ b/linter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.6-SNAPSHOT'
+version = '1.6'
 
 repositories {
     mavenCentral()

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.5-SNAPSHOT'
+version = '1.5'
 
 repositories {
     mavenCentral()

--- a/runner/build.gradle
+++ b/runner/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.6-SNAPSHOT'
+version = '1.6'
 
 repositories {
     mavenCentral()

--- a/token/build.gradle
+++ b/token/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.printscript'
-version = '1.2-SNAPSHOT'
+version = '1.2'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This pull request updates the version numbers for all project modules by removing the `-SNAPSHOT` suffix, indicating that these modules are now considered stable releases rather than development snapshots.

Version updates for stable release:

* Updated the `version` field in the following module build files to remove the `-SNAPSHOT` suffix:
  - [`cli/build.gradle`](diffhunk://#diff-de8fe44d5ac06e1637fb405beaa31259f0a95163399c0f8cb4158c820b9efcd0L7-R7): from `1.5-SNAPSHOT` to `1.5`
  - [`common/build.gradle`](diffhunk://#diff-824c1e8ad11e20caed0bec7162a99779b9a4bcf1178d99fae3e39f69889f8959L6-R6): from `1.2-SNAPSHOT` to `1.2`
  - [`formatter/build.gradle`](diffhunk://#diff-0c3ea61c5b5baf8c519b190b1677556d77f5ee6b9116749aeb9b35b37e0bb951L6-R6): from `3.2-SNAPSHOT` to `3.2`
  - [`interpreter/build.gradle`](diffhunk://#diff-c4a5399386ce09562085a1d203d679cfe83aa4c5ab884612507e7a4431d76d4cL6-R6): from `2.1-SNAPSHOT` to `2.1`
  - [`lexer/build.gradle`](diffhunk://#diff-a987f7f97a40ffbdc40de50df8d383d102d853765aae36fdbb34c1d1ad45ed77L6-R6): from `1.6-SNAPSHOT` to `1.6`
  - [`linter/build.gradle`](diffhunk://#diff-8f5ee92674fa0501f08ebe4f36e7e5103580e399afe9b58928e39d4a34cbfd56L6-R6): from `1.6-SNAPSHOT` to `1.6`
  - [`parser/build.gradle`](diffhunk://#diff-53f6c389782d522fe2b4261a33097ef3edf5fd06b0ae4191a7e603d2642119d7L6-R6): from `1.5-SNAPSHOT` to `1.5`
  - [`runner/build.gradle`](diffhunk://#diff-c1f7cbc6f879317726c68411ee40a42a06778b2350757758c319935da82fd413L6-R6): from `1.6-SNAPSHOT` to `1.6`
  - [`token/build.gradle`](diffhunk://#diff-3e639a6da9adc9cc49c9ecba85bd6075c1aeaabe1510d5d339525caf3cc7ad9fL6-R6): from `1.2-SNAPSHOT` to `1.2`