### PR TITLE
Update GitHub Packages publish credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Publish to GitHub Packages
         run: ./gradlew publish
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_ACTOR: ${{ secrets.GHCR_USER }}
+          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
This pull request updates the environment variables used for publishing to GitHub Packages in the `.github/workflows/publish.yml` workflow. The change switches from using the default GitHub actor and token to using dedicated secrets for authentication.

Authentication update:

* The `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables now use `${{ secrets.GHCR_USER }}` and `${{ secrets.GHCR_TOKEN }}` respectively, instead of `${{ github.actor }}` and `${{ secrets.GH_PAT }}`. This improves security and clarity by using explicit secrets for authentication.